### PR TITLE
Added migration for Hangfire >=1.5

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -115,6 +115,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Install.v4.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Install.v5.sql" />
+  </ItemGroup>
   <!-- <Import Project="..\Common\Hangfire.targets" /> -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Hangfire.PostgreSql/Install.v5.sql
+++ b/src/Hangfire.PostgreSql/Install.v5.sql
@@ -1,0 +1,17 @@
+﻿SET search_path = 'hangfire';
+--
+-- Table structure for table `Schema`
+--
+
+DO
+$$
+BEGIN
+    IF EXISTS (SELECT 1 FROM "schema" WHERE "version" = '5') THEN
+        RAISE EXCEPTION 'version-already-applied';
+    END IF;
+END
+$$;
+
+UPDATE "schema" SET "version" = '5' WHERE "version" = '4';
+
+ALTER TABLE server ALTER COLUMN id TYPE varchar(64);


### PR DESCRIPTION
Due to new format of server name in Hangfire
(https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.Core/Server/BackgroundProcessingServer.cs#L166)
the old size of server.id column is not applicable for storing such strings.