### PR TITLE
Add support for npgsql version 3

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -112,6 +112,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Install.v4.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Install.v5.sql" />
+  </ItemGroup>
   <!-- <Import Project="..\Common\Hangfire.targets" /> -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -50,15 +50,12 @@
     <Reference Include="Hangfire.Core">
       <HintPath>..\..\packages\Hangfire.Core.1.3.4\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Security">
-      <HintPath>..\..\packages\Npgsql.2.2.4.1\lib\net45\Mono.Security.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql">
-      <HintPath>..\..\packages\Npgsql.2.2.4.1\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.0.3.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Npgsql.3.0.3\lib\net45\Npgsql.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Hangfire.PostgreSql/Install.v3.sql
+++ b/src/Hangfire.PostgreSql/Install.v3.sql
@@ -30,10 +30,6 @@ BEGIN
     END IF;
 END
 $$;
- 
-INSERT INTO "schema"("version")
-SELECT 3 "version" WHERE NOT EXISTS (SELECT 1 FROM "schema");
--- version 3 to keep in check with Hangfire SqlServer, but I couldn't keep up with that idea after all;
 
 --
 -- Table structure for table `Counter`

--- a/src/Hangfire.PostgreSql/Install.v4.sql
+++ b/src/Hangfire.PostgreSql/Install.v4.sql
@@ -12,8 +12,6 @@ BEGIN
 END
 $$;
 
-UPDATE "schema" SET "version" = '4' WHERE "version" = '3';
-
 ALTER TABLE "counter" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
 ALTER TABLE "lock" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
 ALTER TABLE "hash" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;

--- a/src/Hangfire.PostgreSql/Install.v5.sql
+++ b/src/Hangfire.PostgreSql/Install.v5.sql
@@ -1,0 +1,15 @@
+﻿SET search_path = 'hangfire';
+--
+-- Table structure for table `Schema`
+--
+
+DO
+$$
+BEGIN
+    IF EXISTS (SELECT 1 FROM "schema" WHERE "version" = '5') THEN
+        RAISE EXCEPTION 'version-already-applied';
+    END IF;
+END
+$$;
+
+ALTER TABLE "server" ALTER COLUMN "id" TYPE VARCHAR(100);

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -71,7 +71,7 @@ SET ""fetchedat"" = NOW() AT TIME ZONE 'UTC'
 WHERE ""id"" IN (
     SELECT ""id"" 
     FROM """ + _options.SchemaName + @""".""jobqueue"" 
-    WHERE ""queue"" = ANY @queues 
+    WHERE ""queue"" = ANY (@queues)
     AND ""fetchedat"" {0} 
     ORDER BY ""fetchedat"", ""jobid""
     LIMIT 1
@@ -140,7 +140,7 @@ RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fe
             string jobToFetchSqlTemplate = @"
 SELECT ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fetchedat"" AS ""FetchedAt"", ""updatecount"" AS ""UpdateCount""
 FROM """ + _options.SchemaName + @""".""jobqueue"" 
-WHERE ""queue"" = ANY @queues 
+WHERE ""queue"" = ANY (@queues)
 AND ""fetchedat"" {0} 
 ORDER BY ""fetchedat"", ""jobid"" 
 LIMIT 1;

--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -426,12 +426,12 @@ WHERE ""key"" = 'recurring-jobs';
 SELECT ""key"", COUNT(""value"") AS ""count"" 
 FROM """ + _options.SchemaName + @""".""counter""
 GROUP BY ""key""
-HAVING ""key"" = ANY @keys;
+HAVING ""key"" = ANY (@keys);
 ";
 
             var valuesMap = connection.Query(
                 sqlQuery,
-                new { keys = keyMaps.Keys })
+                new { keys = keyMaps.Keys.ToList() })
                 .ToDictionary(x => (string)x.key, x => (long)x.count);
 
             foreach (var key in keyMaps.Keys)
@@ -476,13 +476,13 @@ SELECT j.""id"" ""Id"", j.""invocationdata"" ""InvocationData"", j.""arguments""
 FROM """ + _options.SchemaName + @""".""job"" j
 LEFT JOIN """ + _options.SchemaName + @""".""state"" s ON s.""id"" = j.""stateid""
 LEFT JOIN """ + _options.SchemaName + @""".""jobqueue"" jq ON jq.""jobid"" = j.""id""
-WHERE j.""id"" = ANY @jobIds 
+WHERE j.""id"" = ANY (@jobIds)
 AND jq.""fetchedat"" IS NULL;
 ";
 
             var jobs = connection.Query<SqlJob>(
                 enqueuedJobsSql,
-                new { jobIds = jobIds })
+                new { jobIds = jobIds.ToList() })
                 .ToList();
 
             return DeserializeJobs(
@@ -576,13 +576,13 @@ SELECT j.""id"" ""Id"", j.""invocationdata"" ""InvocationData"", j.""arguments""
 FROM """ + _options.SchemaName + @""".""job"" j
 LEFT JOIN """ + _options.SchemaName + @""".""state"" s ON j.""stateid"" = s.""id""
 LEFT JOIN """ + _options.SchemaName + @""".""jobqueue"" jq ON jq.""jobid"" = j.""id""
-WHERE j.""id"" = ANY @jobIds 
+WHERE j.""id"" = ANY (@jobIds)
 AND ""jq"".""fetchedat"" IS NOT NULL;
 ";
 
             var jobs = connection.Query<SqlJob>(
                 fetchedJobsSql,
-                new { jobIds = jobIds })
+                new { jobIds = jobIds.ToList() })
                 .ToList();
 
             var result = new List<KeyValuePair<string, FetchedJobDto>>(jobs.Count);

--- a/src/Hangfire.PostgreSql/packages.config
+++ b/src/Hangfire.PostgreSql/packages.config
@@ -3,6 +3,6 @@
   <package id="Dapper" version="1.38" targetFramework="net45" />
   <package id="Hangfire.Core" version="1.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="Npgsql" version="2.2.4.1" targetFramework="net45" />
+  <package id="Npgsql" version="3.0.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -39,9 +39,6 @@
     <Reference Include="Hangfire.Core">
       <HintPath>..\..\packages\Hangfire.Core.1.3.4\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Security">
-      <HintPath>..\..\packages\Npgsql.2.2.4.1\lib\net45\Mono.Security.dll</HintPath>
-    </Reference>
     <Reference Include="Moq, Version=4.2.1409.1722, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
@@ -50,8 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Npgsql">
-      <HintPath>..\..\packages\Npgsql.2.2.4.1\lib\net45\Npgsql.dll</HintPath>
+    <Reference Include="Npgsql, Version=3.0.3.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Npgsql.3.0.3\lib\net45\Npgsql.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/tests/Hangfire.PostgreSql.Tests/packages.config
+++ b/tests/Hangfire.PostgreSql.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Hangfire.Core" version="1.3.4" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="Npgsql" version="2.2.4.1" targetFramework="net45" />
+  <package id="Npgsql" version="3.0.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This fixes #16. npgsql version 3 is now official and recommended. Following the [migration guide](http://www.npgsql.org/doc/migration-3.0.html) this PR:

 1. Sends IEnumerable parameters as lists (`.ToList()`)
 2. Types parameters as arrays `(@p)` instead of `@p`
 3. Splits `CREATE` statements from `INSERT`/`UPDATE` when creating the schema, due to npgsql/npgsql#641

Have done a bit of testing -- seems to work well :-).