### PR TITLE
fixes warning CS0618: 'NpgsqlException.BaseMessage' is obsolete: 'Use…

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlObjectsInstaller.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlObjectsInstaller.cs
@@ -85,7 +85,7 @@ namespace Hangfire.PostgreSql
                         }
                         catch (NpgsqlException ex)
                         {
-                            if ((ex.BaseMessage ?? "") != "version-already-applied")
+                            if ((ex.MessageText ?? "") != "version-already-applied")
                             {
                                 throw;
                             }


### PR DESCRIPTION
… MessageText instead'