### PR TITLE
fix Npgsql > 3.x removed support for writing a parameter with an IEnu…

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -433,6 +433,7 @@ HAVING ""key"" = ANY (@keys);
             var valuesMap = connection.Query(
                 sqlQuery,
                 new { keys = keyMaps.Keys.ToList() })
+                .ToList()
                 .ToDictionary(x => (string)x.key, x => (long)x.count);
 
             foreach (var key in keyMaps.Keys)


### PR DESCRIPTION
fix Npgsql > 3.x removed support for writing a parameter with an IEnumerable value, use .ToList()/.ToArray() instead

[NotSupportedException: Npgsql > 3.x removed support for writing a parameter with an IEnumerable value, use .ToList()/.ToArray() instead]
   Npgsql.TypeHandlerRegistry.get_Item(Type type) +784
   Npgsql.TypeHandlerRegistry.get_Item(Object value) +258
   Npgsql.NpgsqlParameter.ResolveHandler(TypeHandlerRegistry registry) +169
   Npgsql.NpgsqlParameter.Bind(TypeHandlerRegistry registry) +25
   Npgsql.NpgsqlCommand.ValidateAndCreateMessages(CommandBehavior behavior) +240
   Npgsql.NpgsqlCommand.ExecuteDbDataReaderInternal(CommandBehavior behavior) +231
   Npgsql.NpgsqlCommand.ExecuteDbDataReader(CommandBehavior behavior) +21
   System.Data.Common.DbCommand.System.Data.IDbCommand.ExecuteReader(CommandBehavior behavior) +12
   Dapper.<QueryImpl>d__11`1.MoveNext() +348
   System.Collections.Generic.List`1..ctor(IEnumerable`1 collection) +381
   System.Linq.Enumerable.ToList(IEnumerable`1 source) +58
   Dapper.SqlMapper.Query(IDbConnection cnn, String sql, Object param, IDbTransaction transaction, Boolean buffered, Nullable`1 commandTimeout, Nullable`1 commandType) +340
   Dapper.SqlMapper.Query(IDbConnection cnn, String sql, Object param, IDbTransaction transaction, Boolean buffered, Nullable`1 commandTimeout, Nullable`1 commandType) +67
   Hangfire.PostgreSql.PostgreSqlMonitoringApi.GetTimelineStats(NpgsqlConnection connection, Dictionary`2 keyMaps) +139
   Hangfire.PostgreSql.PostgreSqlMonitoringApi.GetHourlyTimelineStats(NpgsqlConnection connection, String type) +256
   Hangfire.PostgreSql.PostgreSqlMonitoringApi.<HourlySucceededJobs>b__3c(NpgsqlConnection connection) +27
   Hangfire.PostgreSql.PostgreSqlMonitoringApi.UseConnection(Func`2 action) +75
   Hangfire.PostgreSql.PostgreSqlMonitoringApi.HourlySucceededJobs() +59
   Hangfire.Dashboard.Pages.HomePage.Execute() +207
   Hangfire.Dashboard.RazorPage.TransformText(String body) +46
   Hangfire.Dashboard.RazorPage.ToString() +23
   Hangfire.Dashboard.RazorPageDispatcher.Dispatch(RequestDispatcherContext context) +138
   Hangfire.Dashboard.<>c__DisplayClass8.<UseHangfireDashboard>b__4(IDictionary`2 env) +365
   Microsoft.Owin.Mapping.<Invoke>d__0.MoveNext() +275
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Host.SystemWeb.IntegratedPipeline.<RunApp>d__5.MoveNext() +170
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Security.Infrastructure.<Invoke>d__0.MoveNext() +525
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.AspNet.Identity.Owin.<Invoke>d__0.MoveNext() +417
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.AspNet.Identity.Owin.<Invoke>d__0.MoveNext() +417
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.AspNet.Identity.Owin.<Invoke>d__0.MoveNext() +417
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Cors.<Invoke>d__0.MoveNext() +651
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Host.SystemWeb.IntegratedPipeline.<RunApp>d__5.MoveNext() +170
   System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task) +92
   System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task) +58
   System.Runtime.CompilerServices.TaskAwaiter.GetResult() +26
   Microsoft.Owin.Host.SystemWeb.IntegratedPipeline.<DoFinalWork>d__2.MoveNext() +166
   System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() +26
   Microsoft.Owin.Host.SystemWeb.Infrastructure.ErrorState.Rethrow() +26
   Microsoft.Owin.Host.SystemWeb.IntegratedPipeline.StageAsyncResult.End(IAsyncResult ar) +81
   Microsoft.Owin.Host.SystemWeb.IntegratedPipeline.IntegratedPipelineContext.EndFinalWork(IAsyncResult ar) +30
   System.Web.AsyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +380
   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously) +155