### PR TITLE
Update to make compatible with NpgSql 3.1.2

### DIFF
--- a/src/Hangfire.PostgreSql/packages.config
+++ b/src/Hangfire.PostgreSql/packages.config
@@ -3,6 +3,6 @@
   <package id="Dapper" version="1.38" targetFramework="net45" />
   <package id="Hangfire.Core" version="1.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="Npgsql" version="3.0.3" targetFramework="net45" />
+  <package id="Npgsql" version="3.1.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've just upgraded a local project to 3.1.2 of NpgSql and they've changed the exception API quite considerably which breaks your library. Am on mobile at the moment so made the changes in github that I know about - but I'm sure you'll want to just make sure it compiles with the new version directly.

Cheers!