### PR TITLE
Implemented distributed lock timeout

### DIFF
--- a/src/Hangfire.PostgreSql/Entities/JobParameter.cs
+++ b/src/Hangfire.PostgreSql/Entities/JobParameter.cs
@@ -19,8 +19,11 @@
 //   
 //    Special thanks goes to him.
 
+using Hangfire.PostgreSql.Annotations;
+
 namespace Hangfire.PostgreSql.Entities
 {
+    [UsedImplicitly]
     internal class JobParameter
     {
         public int JobId { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/Server.cs
+++ b/src/Hangfire.PostgreSql/Entities/Server.cs
@@ -20,9 +20,11 @@
 //    Special thanks goes to him.
 
 using System;
+using Hangfire.PostgreSql.Annotations;
 
 namespace Hangfire.PostgreSql.Entities
 {
+    [UsedImplicitly]
     internal class Server
     {
         public string Id { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/SqlHash.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlHash.cs
@@ -20,9 +20,11 @@
 //    Special thanks goes to him.
 
 using System;
+using Hangfire.PostgreSql.Annotations;
 
 namespace Hangfire.PostgreSql.Entities
 {
+    [UsedImplicitly]
     internal class SqlHash
     {
         public int Id { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/SqlJob.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlJob.cs
@@ -20,9 +20,11 @@
 //    Special thanks goes to him.
 
 using System;
+using Hangfire.PostgreSql.Annotations;
 
 namespace Hangfire.PostgreSql.Entities
 {
+    [UsedImplicitly]
     internal class SqlJob
     {
         public int Id { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/SqlState.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlState.cs
@@ -20,9 +20,11 @@
 //    Special thanks goes to him.
 
 using System;
+using Hangfire.PostgreSql.Annotations;
 
 namespace Hangfire.PostgreSql.Entities
 {
+    [UsedImplicitly]
     internal class SqlState
     {
         public int JobId { get; set; }

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -120,6 +120,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Install.v6.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Install.v7.sql" />
+  </ItemGroup>
   <!-- <Import Project="..\Common\Hangfire.targets" /> -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Hangfire.PostgreSql/Install.v7.sql
+++ b/src/Hangfire.PostgreSql/Install.v7.sql
@@ -1,0 +1,15 @@
+﻿SET search_path = 'hangfire';
+--
+-- Table structure for table `Schema`
+--
+
+DO
+$$
+BEGIN
+    IF EXISTS (SELECT 1 FROM "schema" WHERE "version"::integer >= 7) THEN
+        RAISE EXCEPTION 'version-already-applied';
+    END IF;
+END
+$$;
+
+ALTER TABLE "lock" ADD COLUMN acquired timestamp without time zone;

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -23,42 +23,68 @@ using System;
 
 namespace Hangfire.PostgreSql
 {
-	public class PostgreSqlStorageOptions
-	{
-		private TimeSpan _queuePollInterval;
+    public class PostgreSqlStorageOptions
+    {
+        private TimeSpan _queuePollInterval;
+        private TimeSpan _invisibilityTimeout;
+        private TimeSpan _distributedLockTimeout;
 
-		public PostgreSqlStorageOptions()
-		{
-			QueuePollInterval = TimeSpan.FromSeconds(15);
-			InvisibilityTimeout = TimeSpan.FromMinutes(30);
-			SchemaName = "hangfire";
-			UseNativeDatabaseTransactions = true;
-			PrepareSchemaIfNecessary = true;
-		}
+        public PostgreSqlStorageOptions()
+        {
+            QueuePollInterval = TimeSpan.FromSeconds(15);
+            InvisibilityTimeout = TimeSpan.FromMinutes(30);
+            DistributedLockTimeout = TimeSpan.FromMinutes(10);
+            SchemaName = "hangfire";
+            UseNativeDatabaseTransactions = true;
+            PrepareSchemaIfNecessary = true;
+        }
 
-		public TimeSpan QueuePollInterval
-		{
-			get { return _queuePollInterval; }
-			set
-			{
-				var message = $"The QueuePollInterval property value should be positive. Given: {value}.";
+        public TimeSpan QueuePollInterval
+        {
+            get { return _queuePollInterval; }
+            set
+            {
+                ThrowIfValueIsNotPositive(value, nameof(QueuePollInterval));
+                _queuePollInterval = value;
+            }
+        }
 
-				if (value == TimeSpan.Zero)
-				{
-					throw new ArgumentException(message, nameof(value));
-				}
-				if (value != value.Duration())
-				{
-					throw new ArgumentException(message, nameof(value));
-				}
+        public TimeSpan InvisibilityTimeout
+        {
+            get { return _invisibilityTimeout; }
+            set
+            {
+                ThrowIfValueIsNotPositive(value, nameof(InvisibilityTimeout));
+                _invisibilityTimeout = value;
+            }
+        }
 
-				_queuePollInterval = value;
-			}
-		}
+        public TimeSpan DistributedLockTimeout
+        {
+            get { return _distributedLockTimeout; }
+            set
+            {
+                ThrowIfValueIsNotPositive(value, nameof(DistributedLockTimeout));
+                _distributedLockTimeout = value;
+            }
+        }
 
-		public TimeSpan InvisibilityTimeout { get; set; }
-		public bool UseNativeDatabaseTransactions { get; set; }
-		public bool PrepareSchemaIfNecessary { get; set; }
-		public string SchemaName { get; set; }
-	}
+        public bool UseNativeDatabaseTransactions { get; set; }
+        public bool PrepareSchemaIfNecessary { get; set; }
+        public string SchemaName { get; set; }
+
+        private static void ThrowIfValueIsNotPositive(TimeSpan value, string fieldName)
+        {
+            var message = $"The {fieldName} property value should be positive. Given: {value}.";
+
+            if (value == TimeSpan.Zero)
+            {
+                throw new ArgumentException(message, nameof(value));
+            }
+            if (value != value.Duration())
+            {
+                throw new ArgumentException(message, nameof(value));
+            }
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
@@ -9,212 +9,237 @@ using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlDistributedLockFacts
-	{
-		private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
+    public class PostgreSqlDistributedLockFacts
+    {
+        private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenResourceIsNullOrEmpty()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenResourceIsNullOrEmpty()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
 
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlDistributedLock("", _timeout, new Mock<IDbConnection>().Object, options));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlDistributedLock("", _timeout, new Mock<IDbConnection>().Object, options));
 
-			Assert.Equal("resource", exception.ParamName);
-		}
+            Assert.Equal("resource", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenConnectionIsNull()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionIsNull()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
 
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlDistributedLock("hello", _timeout, null, options));
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlDistributedLock("hello", _timeout, null, options));
 
-			Assert.Equal("connection", exception.ParamName);
-		}
+            Assert.Equal("connection", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenOptionsIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlDistributedLock("hi", _timeout, new Mock<IDbConnection>().Object, null));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenOptionsIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlDistributedLock("hi", _timeout, new Mock<IDbConnection>().Object, null));
 
-			Assert.Equal("options", exception.ParamName);
-		}
-
-
-		[Fact, CleanDatabase]
-		public void Ctor_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = true
-			};
-
-			UseConnection(connection =>
-			{
-				// ReSharper disable once UnusedVariable
-				var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-
-				var lockCount = connection.Query<long>(
-					@"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
-					new {resource = "hello"}).Single();
-
-				Assert.Equal(lockCount, 1);
-				//Assert.Equal("Exclusive", lockMode);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void Ctor_AcquiresExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions_OnSession()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = false
-			};
-
-			UseConnection(connection =>
-			{
-				// ReSharper disable once UnusedVariable
-				var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-
-				var lockCount = connection.Query<long>(
-					@"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
-					new {resource = "hello"}).Single();
-
-				Assert.Equal(lockCount, 1);
-				//Assert.Equal("Exclusive", lockMode);
-			});
-		}
+            Assert.Equal("options", exception.ParamName);
+        }
 
 
-		[Fact, CleanDatabase]
-		public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithUseNativeDatabaseTransactions()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = true
-			};
+        [Fact, CleanDatabase]
+        public void Ctor_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = true
+            };
 
-			var releaseLock = new ManualResetEventSlim(false);
-			var lockAcquired = new ManualResetEventSlim(false);
+            UseConnection(connection =>
+            {
+                // ReSharper disable once UnusedVariable
+                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
 
-			var thread = new Thread(
-				() => UseConnection(connection1 =>
-				{
-					using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
-					{
-						lockAcquired.Set();
-						releaseLock.Wait();
-					}
-				}));
-			thread.Start();
+                var lockCount = connection.Query<long>(
+                    @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
+                    new { resource = "hello" }).Single();
 
-			lockAcquired.Wait();
+                Assert.Equal(lockCount, 1);
+                //Assert.Equal("Exclusive", lockMode);
+            });
+        }
 
-			UseConnection(connection2 =>
-				Assert.Throws<PostgreSqlDistributedLockException>(
-					() => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
+        [Fact, CleanDatabase]
+        public void Ctor_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession_WhenDeadlockIsOccured()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = true,
+                DistributedLockTimeout = TimeSpan.FromSeconds(10)
+            };
+            
+            UseConnection(connection =>
+            {
+                // Arrange
+                var timeout = TimeSpan.FromSeconds(15);
+                var resourceName = "hello";
+                connection.Execute($@"INSERT INTO ""{GetSchemaName()}"".""lock"" VALUES ('{resourceName}', 0, '{DateTime.UtcNow}')");
 
-			releaseLock.Set();
-			thread.Join();
-		}
+                // Act
+                var distributedLock = new PostgreSqlDistributedLock(resourceName, timeout, connection, options);
 
-		[Fact, CleanDatabase]
-		public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithoutUseNativeDatabaseTransactions()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = false
-			};
+                // Assert
+                Assert.True(distributedLock != null);
+            });
+        }
 
-			var releaseLock = new ManualResetEventSlim(false);
-			var lockAcquired = new ManualResetEventSlim(false);
+        [Fact, CleanDatabase]
+        public void Ctor_AcquiresExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions_OnSession()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = false
+            };
 
-			var thread = new Thread(
-				() => UseConnection(connection1 =>
-				{
-					using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
-					{
-						lockAcquired.Set();
-						releaseLock.Wait();
-					}
-				}));
-			thread.Start();
+            UseConnection(connection =>
+            {
+                // ReSharper disable once UnusedVariable
+                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
 
-			lockAcquired.Wait();
+                var lockCount = connection.Query<long>(
+                    @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
+                    new { resource = "hello" }).Single();
 
-			UseConnection(connection2 =>
-				Assert.Throws<PostgreSqlDistributedLockException>(
-					() => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
-
-			releaseLock.Set();
-			thread.Join();
-		}
-
-
-		[Fact, CleanDatabase]
-		public void Dispose_ReleasesExclusiveApplicationLock_WithUseNativeDatabaseTransactions()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = true
-			};
-
-			UseConnection(connection =>
-			{
-				var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-				distributedLock.Dispose();
-
-				var lockCount = connection.Query<long>(
-					@"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
-					new {resource = "hello"}).Single();
-
-				Assert.Equal(lockCount, 0);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void Dispose_ReleasesExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions()
-		{
-			PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = false
-			};
-
-			UseConnection(connection =>
-			{
-				var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-				distributedLock.Dispose();
-
-				var lockCount = connection.Query<long>(
-					@"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
-					new {resource = "hello"}).Single();
-
-				Assert.Equal(lockCount, 0);
-			});
-		}
+                Assert.Equal(lockCount, 1);
+                //Assert.Equal("Exclusive", lockMode);
+            });
+        }
 
 
-		private void UseConnection(Action<NpgsqlConnection> action)
-		{
-			using (var connection = ConnectionUtils.CreateConnection())
-			{
-				action(connection);
-			}
-		}
+        [Fact, CleanDatabase]
+        public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithUseNativeDatabaseTransactions()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = true
+            };
 
-		private static string GetSchemaName()
-		{
-			return ConnectionUtils.GetSchemaName();
-		}
-	}
+            var releaseLock = new ManualResetEventSlim(false);
+            var lockAcquired = new ManualResetEventSlim(false);
+
+            var thread = new Thread(
+                () => UseConnection(connection1 =>
+                {
+                    using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
+                    {
+                        lockAcquired.Set();
+                        releaseLock.Wait();
+                    }
+                }));
+            thread.Start();
+
+            lockAcquired.Wait();
+
+            UseConnection(connection2 =>
+                Assert.Throws<PostgreSqlDistributedLockException>(
+                    () => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
+
+            releaseLock.Set();
+            thread.Join();
+        }
+
+        [Fact, CleanDatabase]
+        public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithoutUseNativeDatabaseTransactions()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = false
+            };
+
+            var releaseLock = new ManualResetEventSlim(false);
+            var lockAcquired = new ManualResetEventSlim(false);
+
+            var thread = new Thread(
+                () => UseConnection(connection1 =>
+                {
+                    using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
+                    {
+                        lockAcquired.Set();
+                        releaseLock.Wait();
+                    }
+                }));
+            thread.Start();
+
+            lockAcquired.Wait();
+
+            UseConnection(connection2 =>
+                Assert.Throws<PostgreSqlDistributedLockException>(
+                    () => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
+
+            releaseLock.Set();
+            thread.Join();
+        }
+
+
+        [Fact, CleanDatabase]
+        public void Dispose_ReleasesExclusiveApplicationLock_WithUseNativeDatabaseTransactions()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = true
+            };
+
+            UseConnection(connection =>
+            {
+                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
+                distributedLock.Dispose();
+
+                var lockCount = connection.Query<long>(
+                    @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
+                    new { resource = "hello" }).Single();
+
+                Assert.Equal(lockCount, 0);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void Dispose_ReleasesExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions()
+        {
+            PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                UseNativeDatabaseTransactions = false
+            };
+
+            UseConnection(connection =>
+            {
+                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
+                distributedLock.Dispose();
+
+                var lockCount = connection.Query<long>(
+                    @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
+                    new { resource = "hello" }).Single();
+
+                Assert.Equal(lockCount, 0);
+            });
+        }
+
+
+        private void UseConnection(Action<NpgsqlConnection> action)
+        {
+            using (var connection = ConnectionUtils.CreateConnection())
+            {
+                action(connection);
+            }
+        }
+
+        private static string GetSchemaName()
+        {
+            return ConnectionUtils.GetSchemaName();
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageOptionsFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageOptionsFacts.cs
@@ -3,40 +3,89 @@ using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlStorageOptionsFacts
-	{
-		[Fact]
-		public void Ctor_SetsTheDefaultOptions()
-		{
-			var options = new PostgreSqlStorageOptions();
+    public class PostgreSqlStorageOptionsFacts
+    {
+        [Fact]
+        public void Ctor_SetsTheDefaultOptions()
+        {
+            var options = new PostgreSqlStorageOptions();
 
-			Assert.True(options.QueuePollInterval > TimeSpan.Zero);
-			Assert.True(options.InvisibilityTimeout > TimeSpan.Zero);
-			Assert.True(options.PrepareSchemaIfNecessary);
-		}
+            Assert.True(options.QueuePollInterval > TimeSpan.Zero);
+            Assert.True(options.InvisibilityTimeout > TimeSpan.Zero);
+            Assert.True(options.DistributedLockTimeout > TimeSpan.Zero);
+            Assert.True(options.PrepareSchemaIfNecessary);
+        }
 
-		[Fact]
-		public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsEqualToZero()
-		{
-			var options = new PostgreSqlStorageOptions();
-			Assert.Throws<ArgumentException>(
-				() => options.QueuePollInterval = TimeSpan.Zero);
-		}
+        [Fact]
+        public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsEqualToZero()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.QueuePollInterval = TimeSpan.Zero);
+        }
 
-		[Fact]
-		public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsNegative()
-		{
-			var options = new PostgreSqlStorageOptions();
-			Assert.Throws<ArgumentException>(
-				() => options.QueuePollInterval = TimeSpan.FromSeconds(-1));
-		}
+        [Fact]
+        public void Set_QueuePollInterval_ShouldThrowAnException_WhenGivenIntervalIsNegative()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.QueuePollInterval = TimeSpan.FromSeconds(-1));
+        }
 
-		[Fact]
-		public void Set_QueuePollInterval_SetsTheValue()
-		{
-			var options = new PostgreSqlStorageOptions();
-			options.QueuePollInterval = TimeSpan.FromSeconds(1);
-			Assert.Equal(TimeSpan.FromSeconds(1), options.QueuePollInterval);
-		}
-	}
+        [Fact]
+        public void Set_QueuePollInterval_SetsTheValue()
+        {
+            var options = new PostgreSqlStorageOptions();
+            options.QueuePollInterval = TimeSpan.FromSeconds(1);
+            Assert.Equal(TimeSpan.FromSeconds(1), options.QueuePollInterval);
+        }
+
+        [Fact]
+        public void Set_InvisibilityTimeout_ShouldThrowAnException_WhenGivenIntervalIsEqualToZero()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.InvisibilityTimeout = TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Set_InvisibilityTimeout_ShouldThrowAnException_WhenGivenIntervalIsNegative()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.InvisibilityTimeout = TimeSpan.FromSeconds(-1));
+        }
+
+        [Fact]
+        public void Set_InvisibilityTimeout_SetsTheValue()
+        {
+            var options = new PostgreSqlStorageOptions();
+            options.InvisibilityTimeout = TimeSpan.FromSeconds(1);
+            Assert.Equal(TimeSpan.FromSeconds(1), options.InvisibilityTimeout);
+        }
+
+        [Fact]
+        public void Set_DistributedLockTimeout_ShouldThrowAnException_WhenGivenIntervalIsEqualToZero()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.DistributedLockTimeout = TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Set_DistributedLockTimeout_ShouldThrowAnException_WhenGivenIntervalIsNegative()
+        {
+            var options = new PostgreSqlStorageOptions();
+            Assert.Throws<ArgumentException>(
+                () => options.DistributedLockTimeout = TimeSpan.FromSeconds(-1));
+        }
+
+        [Fact]
+        public void Set_DistributedLockTimeout_SetsTheValue()
+        {
+            var options = new PostgreSqlStorageOptions();
+            options.DistributedLockTimeout = TimeSpan.FromSeconds(1);
+            Assert.Equal(TimeSpan.FromSeconds(1), options.DistributedLockTimeout);
+        }
+    }
 }


### PR DESCRIPTION
Sometimes I faced problem when my service is stopped incorrectly and in this case distributed lock becomes "dead". After restarting service it couldn't fetch any jobs. My workaround was to manually clean lock table in db, so I decided to implement distributed lock timeout.

In this commit:
- Added option DistributedLockTimeout to PostgreSqlStorageOption
- Implemented removing dead locks in PostgresDistributedLock
- Added schema migration (added column "acquired" to "lock" table)
- Updated test cases 
- Db entities marked as UsedImplicilty