### PR TITLE
Appveyor tests discovery should be disabled

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,4 @@ build_script:
     .nuget\NuGet.exe install .nuget\packages.config -OutputDirectory packages
 
     powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& {Import-Module '.\packages\psake.*\tools\psake.psm1'; invoke-psake .\psake-project.ps1 -framework "4.6" test; if ($LastExitCode -and $LastExitCode -ne 0) {write-host "ERROR CODE: $LastExitCode" -fore RED; exit $lastexitcode} }"
+test: off


### PR DESCRIPTION
Appveyor test discovery fails to correctly run .net core tests and should be disabled. Tests would be started by build script.

https://ci.appveyor.com/project/SonicGD/hangfire-postgresql/build/1.4.0.28 - now green