### PR TITLE
Nuget packaging for .net core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,7 +223,4 @@ _site
 *.userprefs
 src/Hangfire.PostgreSql/.vs/restore.dg
 src/Hangfire.PostgreSql/project.lock.json
-/src/Hangfire.PostgreSql.NetCore/project.lock.json
-
-# dotnet core
-*.lock.json
+*/**/project.lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ _site
 src/Hangfire.PostgreSql/.vs/restore.dg
 src/Hangfire.PostgreSql/project.lock.json
 /src/Hangfire.PostgreSql.NetCore/project.lock.json
+
+# dotnet core
+*.lock.json

--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-  "projects": [ "src" ]
+  "projects": [ "src" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
 }

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -42,7 +42,7 @@ Task Merge -Depends Test -Description "Run ILMerge /internalize to merge assembl
 
 Task Collect -Depends Merge -Description "Copy all artifacts to the build folder." {
     Collect-Assembly "Hangfire.PostgreSql" "Net45"
-
+	Collect-Assembly "Hangfire.PostgreSql.NetCore" "netcoreapp1.0"
     Collect-Content "content\readme.txt"
 }
 

--- a/psake-project.ps1
+++ b/psake-project.ps1
@@ -27,7 +27,7 @@ Properties {
     $sharedAssemblyInfo = "$src_dir\SharedAssemblyInfo.cs"
 }
 
-Task Default -Depends Collect
+Task Default -Depends Pack
 
 Task Test -Depends Compile -Description "Run unit and integration tests." {
     Run-XunitTests "Hangfire.PostgreSql.Tests"
@@ -166,7 +166,13 @@ function Collect-Assembly($project, $version) {
 
     "Collecting assembly '$assembly.dll' into '$version'..."
 
-    $source = (Get-SrcOutputDir $projectDir) + "\$assembly.*"
+	$fullProjectDir = Get-SrcOutputDir $projectDir
+	if (Test-Path "$fullProjectDir\$version"){
+		$source = "$fullProjectDir\$version\$assembly.*"
+	}
+	else{
+		$source = "$fullProjectDir\$assembly.*"
+	}
     $destination = "$build_dir\$version"
 
     Create-Directory $destination


### PR DESCRIPTION
This allows to pack both `net452` and `coreapp`. Explanation of changes:
1) `.gitignore` -  explude project.lock.json located in _tests_ 
2) `global.json` - since preview 4 of SDK released which relies on `cproj` and not `project.json` I had to lock the version of SDK to `1.0.0-preview2-003121`, otherwise `dotnet` will pick the latest version of SDK installed on machine and this won't find cproj file, thus the build will fail. The other option is to migrate to cproj. I don't mind doing it, but personally think it is too soon. LMK what you think.

#54 