### PR TITLE
Set lock resource column to TEXT type

### DIFF
--- a/src/Hangfire.PostgreSql/Install.v9.sql
+++ b/src/Hangfire.PostgreSql/Install.v9.sql
@@ -1,0 +1,15 @@
+SET search_path = 'hangfire';
+--
+-- Table structure for table `Schema`
+--
+
+DO
+$$
+BEGIN
+    IF EXISTS (SELECT 1 FROM "schema" WHERE "version"::integer >= 8) THEN
+        RAISE EXCEPTION 'version-already-applied';
+    END IF;
+END
+$$;
+
+ALTER TABLE "lock" ALTER COLUMN "resource" TYPE TEXT;


### PR DESCRIPTION
Resource name should not be limited by size.

This is making Hangfire fail when queue names are longer than 100 characters.

We applied this change in our systems to fix the issue.

Also more globally, limits should not be applied to character varying on PostgreSQL. (TEXT is always the way to go): https://dba.stackexchange.com/questions/20974/should-i-add-an-arbitrary-length-limit-to-varchar-columns