### PR TITLE
Upgrade to netstandard2 and Npgsql 4.0.3 - Issue #89

### DIFF
--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -29,7 +29,7 @@ using Hangfire.Server;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
     public
 #else
 	internal
@@ -39,7 +39,7 @@ namespace Hangfire.PostgreSql
         private static readonly TimeSpan DelayBetweenPasses = TimeSpan.FromSeconds(1);
         private const int NumberOfRecordsInSinglePass = 1000;
 
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(ExpirationManager));
 #else
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <Description>PostgreSql storage implementation for Hangfire (background job system for ASP.NET applications).</Description>
-    <Copyright>Copyright © 2014-2017 Frank Hommers and others</Copyright>
+    <Copyright>Copyright © 2014-2018 Frank Hommers and others</Copyright>
     <AssemblyTitle>Hangfire PostgreSql Storage</AssemblyTitle>
-    <VersionPrefix>1.4.6</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>Frank Hommers and others (Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Ben Herila (bherila), Vytautas Kasparavičius (vytautask)</Authors>
-    <TargetFrameworks>netstandard1.4;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Hangfire.PostgreSql</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Hangfire.PostgreSql</PackageId>
@@ -14,9 +14,9 @@
     <PackageReleaseNotes>https://github.com/frankhommers/Hangfire.PostgreSql/releases</PackageReleaseNotes>
     <PackageProjectUrl>http://hmm.rs/Hangfire.PostgreSql</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.github.com/frankhommers/Hangfire.PostgreSql/master/LICENSE.md</PackageLicenseUrl>
-    <Version>1.4.8.1</Version>
-    <FileVersion>1.4.8.1</FileVersion>
-    <AssemblyVersion>1.4.8.1</AssemblyVersion>
+    <Version>1.5.0</Version>
+    <FileVersion>1.5.0</FileVersion>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
@@ -25,15 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
-    <PackageReference Include="Hangfire.Core" Version="1.6.14" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="Npgsql" Version="3.2.2" />
+    <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="Hangfire.Core" Version="1.6.20" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Npgsql" Version="4.0.3" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <DefineConstants>$(DefineConstants);NETCORE1</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Configuration" />

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
@@ -27,12 +27,12 @@ using Dapper;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
-	public
+#if (NETSTANDARD2_0)
+    public
 #else
 	internal
 #endif
-	sealed class PostgreSqlDistributedLock : IDisposable
+    sealed class PostgreSqlDistributedLock : IDisposable
     {
         private readonly string _resource;
         private readonly IDbConnection _connection;

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
@@ -23,8 +23,8 @@ using System;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
-	public
+#if (NETSTANDARD2_0)
+    public
 #else
     [Serializable]
 	internal

--- a/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
@@ -26,12 +26,12 @@ using Hangfire.Storage;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
-	public
+#if (NETSTANDARD2_0)
+    public
 #else
 	internal
 #endif
-	class PostgreSqlFetchedJob : IFetchedJob
+    class PostgreSqlFetchedJob : IFetchedJob
     {
         private readonly IDbConnection _connection;
         private readonly PostgreSqlStorageOptions _options;

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -114,7 +114,7 @@ RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fe
 					{
 						NpgsqlException npgSqlException = ex as NpgsqlException;
 						PostgresException postgresException = ex as PostgresException;
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
                         bool smoothException = false;
 #else
                         bool smoothException = npgSqlException?.ErrorCode == 40001;

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueueProvider.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueueProvider.cs
@@ -24,12 +24,12 @@ using System.Data;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
 	public
 #else
-	internal
+    internal
 #endif
-	class PostgreSqlJobQueueProvider : IPersistentJobQueueProvider
+    class PostgreSqlJobQueueProvider : IPersistentJobQueueProvider
     {
         private readonly PostgreSqlStorageOptions _options;
 

--- a/src/Hangfire.PostgreSql/PostgreSqlObjectsInstaller.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlObjectsInstaller.cs
@@ -32,7 +32,7 @@ using Dapper;
 
 namespace Hangfire.PostgreSql
 {
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
     public
 #else
     [ExcludeFromCodeCoverage]

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -21,7 +21,7 @@
 
 using System;
 using System.Collections.Generic;
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
 #else
 using System.Configuration;
 #endif
@@ -67,15 +67,15 @@ namespace Hangfire.PostgreSql
 			{
 				_connectionString = nameOrConnectionString;
 			}
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
 #else
 			else if (IsConnectionStringInConfiguration(nameOrConnectionString))
 			{
 				_connectionString = ConfigurationManager.ConnectionStrings[nameOrConnectionString].ConnectionString;
 			}
 #endif
-			else
-			{
+            else
+            {
 				throw new ArgumentException(
 					$"Could not find connection string with name '{nameOrConnectionString}' in application config file");
 			}
@@ -204,7 +204,7 @@ namespace Hangfire.PostgreSql
 
 		private bool IsConnectionStringInConfiguration(string connectionStringName)
 		{
-#if (NETCORE1 || NETCORE50 || NETSTANDARD1_5 || NETSTANDARD1_6)
+#if (NETSTANDARD2_0)
             return false;
 #else
             var connectionStringSetting = ConfigurationManager.ConnectionStrings[connectionStringName];

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <AssemblyTitle>Hangfire.PostgreSql.Tests</AssemblyTitle>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Hangfire.PostgreSql.Tests</AssemblyName>
     <PackageId>Hangfire.PostgreSql.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.1.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Npgsql 4 supports netstandard2 only, so support for netstandard 1.* has been removed. 