### PR TITLE
migrate id's from int to long

### DIFF
--- a/src/Hangfire.PostgreSql/Entities/JobParameter.cs
+++ b/src/Hangfire.PostgreSql/Entities/JobParameter.cs
@@ -26,7 +26,7 @@ namespace Hangfire.PostgreSql.Entities
     [UsedImplicitly]
     internal class JobParameter
     {
-        public int JobId { get; set; }
+        public long JobId { get; set; }
         public string Name { get; set; }
         public string Value { get; set; }
     }

--- a/src/Hangfire.PostgreSql/Entities/SqlHash.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlHash.cs
@@ -27,7 +27,7 @@ namespace Hangfire.PostgreSql.Entities
     [UsedImplicitly]
     internal class SqlHash
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string Key { get; set; }
         public string Field { get; set; }
         public string Value { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/SqlJob.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlJob.cs
@@ -1,5 +1,5 @@
 // This file is part of Hangfire.PostgreSql.
-// Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
+// Copyright ï¿½ 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
 // 
 // Hangfire.PostgreSql is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as 
@@ -27,7 +27,7 @@ namespace Hangfire.PostgreSql.Entities
     [UsedImplicitly]
     internal class SqlJob
     {
-        public int Id { get; set; }
+        public long Id { get; set; }
         public string InvocationData { get; set; }
         public string Arguments { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/src/Hangfire.PostgreSql/Entities/SqlState.cs
+++ b/src/Hangfire.PostgreSql/Entities/SqlState.cs
@@ -27,7 +27,7 @@ namespace Hangfire.PostgreSql.Entities
     [UsedImplicitly]
     internal class SqlState
     {
-        public int JobId { get; set; }
+        public long JobId { get; set; }
         public string Name { get; set; }
         public string Reason { get; set; }
         public DateTime CreatedAt { get; set; }

--- a/src/Hangfire.PostgreSql/IPersistentJobQueueMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/IPersistentJobQueueMonitoringApi.cs
@@ -26,8 +26,8 @@ namespace Hangfire.PostgreSql
     public interface IPersistentJobQueueMonitoringApi
     {
         IEnumerable<string> GetQueues();
-        IEnumerable<int> GetEnqueuedJobIds(string queue, int from, int perPage);
-        IEnumerable<int> GetFetchedJobIds(string queue, int from, int perPage);
+        IEnumerable<long> GetEnqueuedJobIds(string queue, int from, int perPage);
+        IEnumerable<long> GetFetchedJobIds(string queue, int from, int perPage);
         EnqueuedAndFetchedCountDto GetEnqueuedAndFetchedCount(string queue);
     }
 }

--- a/src/Hangfire.PostgreSql/Install.v11.sql
+++ b/src/Hangfire.PostgreSql/Install.v11.sql
@@ -1,0 +1,33 @@
+SET search_path = 'hangfire';
+
+
+
+DO
+$$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "schema" WHERE "version"::integer >= 11) THEN
+    RAISE EXCEPTION 'version-already-applied';
+  END IF;
+END
+$$;
+
+ALTER TABLE hangfire.counter ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.counter_id_seq AS BIGINT; 
+ALTER TABLE hangfire.hash ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.hash_id_seq AS BIGINT;
+ALTER TABLE hangfire.job ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.job_id_seq AS BIGINT;
+ALTER TABLE hangfire.job ALTER COLUMN stateid TYPE BIGINT;
+ALTER TABLE hangfire.state ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.state_id_seq AS BIGINT;
+ALTER TABLE hangfire.state ALTER COLUMN jobid TYPE BIGINT;
+ALTER TABLE hangfire.jobparameter ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.jobparameter_id_seq AS BIGINT;
+ALTER TABLE hangfire.jobparameter ALTER COLUMN jobid TYPE BIGINT;
+ALTER TABLE hangfire.jobqueue ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.jobqueue_id_seq AS BIGINT;
+ALTER TABLE hangfire.jobqueue ALTER COLUMN jobid TYPE BIGINT;
+ALTER TABLE hangfire.list ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.list_id_seq AS BIGINT;
+ALTER TABLE hangfire.set ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE hangfire.set_id_seq AS BIGINT;

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -128,7 +128,7 @@ RETURNING ""id"";
 
 			var invocationData = InvocationData.Serialize(job);
 
-			var jobId = _connection.Query<int>(
+			var jobId = _connection.Query<long>(
 				createJobSql,
 				new
 				{

--- a/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
@@ -42,7 +42,7 @@ namespace Hangfire.PostgreSql
         public PostgreSqlFetchedJob(
             IDbConnection connection, 
             PostgreSqlStorageOptions options,
-            int id, 
+            long id, 
             string jobId, 
             string queue)
         {
@@ -59,7 +59,7 @@ namespace Hangfire.PostgreSql
             Queue = queue;
         }
 
-        public int Id { get; private set; }
+        public long Id { get; private set; }
         public string JobId { get; private set; }
         public string Queue { get; private set; }
 

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -239,8 +239,8 @@ VALUES (@jobId, @queue);
 		[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 		private class FetchedJob
 		{
-			public int Id { get; set; }
-			public int JobId { get; set; }
+			public long Id { get; set; }
+			public long JobId { get; set; }
 			public string Queue { get; set; }
 			public DateTime? FetchedAt { get; set; }
 			public int UpdateCount { get; set; }

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueueMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueueMonitoringApi.cs
@@ -50,12 +50,12 @@ FROM """ + _options.SchemaName + @""".""jobqueue"";
             return _connection.Query(sqlQuery).Select(x => (string)x.queue).ToList();
         }
 
-        public IEnumerable<int> GetEnqueuedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetEnqueuedJobIds(string queue, int @from, int perPage)
         {
             return GetQueuedOrFetchedJobIds(queue, false, @from, perPage);
         }
 
-        private IEnumerable<int> GetQueuedOrFetchedJobIds(string queue, bool fetched, int @from, int perPage)
+        private IEnumerable<long> GetQueuedOrFetchedJobIds(string queue, bool fetched, int @from, int perPage)
         {
             string sqlQuery = string.Format(@"
 SELECT j.""id"" 
@@ -67,13 +67,13 @@ AND j.""id"" IS NOT NULL
 LIMIT @count OFFSET @start;
 ", fetched ? "IS NOT NULL" : "IS NULL");
 
-            return _connection.Query<int>(
+            return _connection.Query<long>(
                 sqlQuery,
                 new {queue = queue, start = @from, count = perPage})
                 .ToList();
         }
 
-        public IEnumerable<int> GetFetchedJobIds(string queue, int @from, int perPage)
+        public IEnumerable<long> GetFetchedJobIds(string queue, int @from, int perPage)
         {
             return GetQueuedOrFetchedJobIds(queue, true, @from, perPage);
         }

--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -473,7 +473,7 @@ GROUP BY ""key"";
             }
         }
 
-        private JobList<EnqueuedJobDto> EnqueuedJobs(NpgsqlConnection connection, IEnumerable<int> jobIds)
+        private JobList<EnqueuedJobDto> EnqueuedJobs(NpgsqlConnection connection, IEnumerable<long> jobIds)
         {
             string enqueuedJobsSql = @"
 SELECT j.""id"" ""Id"", j.""invocationdata"" ""InvocationData"", j.""arguments"" ""Arguments"", j.""createdat"" ""CreatedAt"", j.""expireat"" ""ExpireAt"", s.""name"" ""StateName"", s.""reason"" ""StateReason"", s.""data"" ""StateData""
@@ -581,7 +581,7 @@ LIMIT @count OFFSET @start;
 
         private JobList<FetchedJobDto> FetchedJobs(
             NpgsqlConnection connection,
-            IEnumerable<int> jobIds)
+            IEnumerable<long> jobIds)
         {
             string fetchedJobsSql = @"
 SELECT j.""id"" ""Id"", j.""invocationdata"" ""InvocationData"", j.""arguments"" ""Arguments"", j.""createdat"" ""CreatedAt"", 

--- a/tests/Hangfire.PostgreSql.Tests/ExpirationManagerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/ExpirationManagerFacts.cs
@@ -201,7 +201,7 @@ values ('key', 'field', '', @expireAt)";
             }
         }
 
-        private static int CreateExpirationEntry(NpgsqlConnection connection, DateTime? expireAt)
+        private static long CreateExpirationEntry(NpgsqlConnection connection, DateTime? expireAt)
         {
             string insertSqlNull = @"
 insert into """ + GetSchemaName() + @""".""counter""(""key"", ""value"", ""expireat"")
@@ -217,11 +217,11 @@ values ('key', 1, now() at time zone 'utc' - interval '{0} seconds') returning "
                     ((long)(DateTime.UtcNow - expireAt.Value).TotalSeconds).ToString(CultureInfo.InvariantCulture));
 
             var id = connection.Query(insertSql).Single();
-            var recordId = (int)id.id;
+            var recordId = (long)id.id;
             return recordId;
         }
 
-        private static bool IsEntryExpired(NpgsqlConnection connection, int entryId)
+        private static bool IsEntryExpired(NpgsqlConnection connection, long entryId)
         {
             var count = connection.Query<long>(
                 @"select count(*) from """ + GetSchemaName() + @""".""counter"" where ""id"" = @id", new { id = entryId }).Single();

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
@@ -191,7 +191,7 @@ namespace Hangfire.PostgreSql.Tests
 				var sqlJob = sql.Query(@"select * from """ + GetSchemaName() + @""".""job""").Single();
 				Assert.Equal(jobId, sqlJob.id.ToString());
 				Assert.Equal(createdAt, sqlJob.createdat);
-				Assert.Null((int?) sqlJob.stateid);
+				Assert.Null((long?) sqlJob.stateid);
 				Assert.Null((string) sqlJob.statename);
 
 				var invocationData = JobHelper.FromJson<InvocationData>((string) sqlJob.invocationdata);
@@ -243,7 +243,7 @@ values (@invocationData, @arguments, @stateName, now() at time zone 'utc') retur
 			{
 				var job = Job.FromExpression(() => SampleMethod("wrong"));
 
-                var jobId = (int) sql.Query(
+                var jobId = (long) sql.Query(
 					arrangeSql,
 					new
 					{
@@ -312,9 +312,9 @@ returning ""id"";";
 					{"Key", "Value"}
 				};
 
-				var jobId = (int) sql.Query(createJobSql).Single().id;
+				var jobId = (long) sql.Query(createJobSql).Single().id;
 
-				var stateId = (int) sql.Query(
+				var stateId = (long) sql.Query(
 					createStateSql,
 					new {jobId = jobId, name = "Name", reason = "Reason", @data = JobHelper.ToJson(data)}).Single().id;
 
@@ -347,7 +347,7 @@ values (@invocationData, @arguments, @stateName, now() at time zone 'utc') retur
 						arguments = "['Arguments']"
 					}).Single();
 
-				var result = connection.GetJobData(((int) jobId.id).ToString());
+				var result = connection.GetJobData(((long) jobId.id).ToString());
 
 				Assert.NotNull(result.LoadException);
 			});
@@ -493,7 +493,7 @@ RETURNING ""jobid"";
 ";
 			UseConnections((sql, connection) =>
 			{
-				var id = sql.Query<int>(
+				var id = sql.Query<long>(
 					arrangeSql,
 					new {name = "name", value = "value"}).Single();
 

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
@@ -146,14 +146,14 @@ namespace Hangfire.PostgreSql.Tests
 			});
 		}
 
-		private static int CreateJobQueueRecord(IDbConnection connection, string jobId, string queue)
+		private static long CreateJobQueueRecord(IDbConnection connection, string jobId, string queue)
 		{
 			string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"", ""fetchedat"")
 values (@id, @queue, now() at time zone 'utc') returning ""id""";
 
 			return
-				(int)
+				(long)
 					connection.Query(arrangeSql, new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue})
 						.Single()
 						.id;

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -162,7 +162,7 @@ values (@jobId, @queue) returning ""id""";
 			// Arrange
 			UseConnection(connection =>
 			{
-				var id = (int) connection.Query(
+				var id = (long) connection.Query(
 					arrangeSql,
 					new {jobId = 1, queue = "default"}).Single().id;
 				var queue = CreateJobQueue(connection, useNativeDatabaseTransactions);


### PR DESCRIPTION
this migrate's all int's to long so that there is a bigger amount of id's that could be handled with Hangfire.PostgreSql.

Another good extension would be to cycle the sequences.
Currently PostgreSql has support for that, however that assumes, that no old id exists, which is problematic since failed jobs are still inside the JobId table.
