### PR TITLE
Don't alter sequences as they're already bigint

### DIFF
--- a/src/Hangfire.PostgreSql/Install.v11.sql
+++ b/src/Hangfire.PostgreSql/Install.v11.sql
@@ -12,22 +12,14 @@ END
 $$;
 
 ALTER TABLE hangfire.counter ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.counter_id_seq AS BIGINT; 
 ALTER TABLE hangfire.hash ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.hash_id_seq AS BIGINT;
 ALTER TABLE hangfire.job ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.job_id_seq AS BIGINT;
 ALTER TABLE hangfire.job ALTER COLUMN stateid TYPE BIGINT;
 ALTER TABLE hangfire.state ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.state_id_seq AS BIGINT;
 ALTER TABLE hangfire.state ALTER COLUMN jobid TYPE BIGINT;
 ALTER TABLE hangfire.jobparameter ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.jobparameter_id_seq AS BIGINT;
 ALTER TABLE hangfire.jobparameter ALTER COLUMN jobid TYPE BIGINT;
 ALTER TABLE hangfire.jobqueue ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.jobqueue_id_seq AS BIGINT;
 ALTER TABLE hangfire.jobqueue ALTER COLUMN jobid TYPE BIGINT;
 ALTER TABLE hangfire.list ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.list_id_seq AS BIGINT;
 ALTER TABLE hangfire.set ALTER COLUMN id TYPE BIGINT;
-ALTER SEQUENCE hangfire.set_id_seq AS BIGINT;


### PR DESCRIPTION
From Postgres documentation:

> Sequences are based on bigint arithmetic, so the range cannot exceed the range of an eight-byte integer (-9223372036854775808 to 9223372036854775807).

I also checked that current sequence (before v11 migration) max value is set to 9223372036854775807 as expected via:

```sql
SELECT max_value FROM job_id_seq;
```

Fixes #111.

More info [here](https://github.com/frankhommers/Hangfire.PostgreSql/issues/111#issuecomment-504794536).