### PR TITLE
Changes to fix the connection issues for both Non-SSL and SSL encrypted databases (#124 and #127)

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -468,6 +468,7 @@ GROUP BY ""key"";
         {
             using (var connection = GetConnection())
             {
+                connection.Open();
                 return action(connection);
             }
         }

--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -36,16 +36,19 @@ namespace Hangfire.PostgreSql
 {
     public class PostgreSqlMonitoringApi : IMonitoringApi
     {
-        private readonly NpgsqlConnection _connection;
+        private readonly string _connectionString;
+        private readonly Action<NpgsqlConnection> _connectionSetup;
         private readonly PostgreSqlStorageOptions _options;
         private readonly PersistentJobQueueProviderCollection _queueProviders;
 
         public PostgreSqlMonitoringApi(
-            NpgsqlConnection connection,
+            string connectionString,
+            Action<NpgsqlConnection> connectionSetup,
             PostgreSqlStorageOptions options,
             PersistentJobQueueProviderCollection queueProviders)
         {
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+            _connectionSetup = connectionSetup;
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _queueProviders = queueProviders ?? throw new ArgumentNullException(nameof(queueProviders));
         }
@@ -387,7 +390,12 @@ WHERE ""key"" = 'recurring-jobs';
             });
         }
 
-        protected virtual NpgsqlConnection GetConnection() => _connection;
+        protected virtual NpgsqlConnection GetConnection()
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            _connectionSetup?.Invoke(connection);
+            return connection;
+        }
 
         private Dictionary<DateTime, long> GetHourlyTimelineStats(
             NpgsqlConnection connection,

--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -466,7 +466,10 @@ GROUP BY ""key"";
 
         private T UseConnection<T>(Func<NpgsqlConnection, T> action)
         {
-            return action(GetConnection());
+            using (var connection = GetConnection())
+            {
+                return action(connection);
+            }
         }
 
         private JobList<EnqueuedJobDto> EnqueuedJobs(NpgsqlConnection connection, IEnumerable<long> jobIds)

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -41,7 +41,7 @@ namespace Hangfire.PostgreSql
         private readonly string _connectionString;
 
         public PostgreSqlStorage(string nameOrConnectionString)
-            : this(nameOrConnectionString, null, new PostgreSqlStorageOptions())
+            : this(nameOrConnectionString, new PostgreSqlStorageOptions())
         {
         }
 
@@ -145,7 +145,6 @@ namespace Hangfire.PostgreSql
         public override IStorageConnection GetConnection()
         {
             var connection = _existingConnection ?? CreateAndOpenConnection();
-            _connectionSetup?.Invoke(connection);
 
             return new PostgreSqlConnection(connection, QueueProviders, _options, _existingConnection == null);
         }
@@ -196,6 +195,8 @@ namespace Hangfire.PostgreSql
             };
 
             var connection = new NpgsqlConnection(connectionStringBuilder.ToString());
+
+            _connectionSetup?.Invoke(connection);
             connection.Open();
 
             return connection;

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -139,10 +139,7 @@ namespace Hangfire.PostgreSql
 
         public override IMonitoringApi GetMonitoringApi()
         {
-            var connection = _existingConnection ?? CreateAndOpenConnection();
-            _connectionSetup?.Invoke(connection);
-
-            return new PostgreSqlMonitoringApi(connection, _options, QueueProviders);
+            return new PostgreSqlMonitoringApi(_connectionString, _connectionSetup, _options, QueueProviders);
         }
 
         public override IStorageConnection GetConnection()

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -18,16 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Certificates\**" />
-    <EmbeddedResource Remove="Certificates\**" />
-    <None Remove="Certificates\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Scripts\Clean.sql" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Scripts\Clean.sql" />
   </ItemGroup>
 

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -18,7 +18,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Scripts\Clean.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Scripts\Clean.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Scripts\Clean.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -18,17 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Scripts\Clean.sql" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Scripts\Clean.sql" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Scripts\Clean.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
@@ -31,7 +31,7 @@ namespace Hangfire.PostgreSql.Tests
                 SchemaName = ConnectionUtils.GetSchemaName()
             };
 
-            _storage = new PostgreSqlStorage(ConnectionUtils.CreateConnection(), _options);
+            _storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString(), _options);
         }
 
         [Fact, CleanDatabase]

--- a/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
@@ -14,9 +14,9 @@ namespace Hangfire.PostgreSql.Tests
 		private const string DefaultDatabaseName = @"hangfire_tests";
 		private const string DefaultSchemaName = @"hangfire";
 
-		private const string DefaultConnectionStringTemplate = @"Server=127.0.0.1;Port=5432;Database=postgres;User Id=postgres;Password=password;";
+	    private const string DefaultConnectionStringTemplate = @"Server=127.0.0.1;Port=5432;Database=postgres;User Id=postgres;Password=password;";
 
-		public static string GetDatabaseName()
+        public static string GetDatabaseName()
 		{
 			return Environment.GetEnvironmentVariable(DatabaseVariable) ?? DefaultDatabaseName;
 		}


### PR DESCRIPTION
Cause of the connection issues:
The "_existingConnection" property was NULL when calling the "GetMonitoringApi" method, which resulted in a new connection each time calling it.

Fixes #124 and fixes #127 