### PR TITLE
Set Transaction Timeout of TransactionScope to maximum value.

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -69,7 +69,7 @@ namespace Hangfire.PostgreSql
             var transactionOptions = new TransactionOptions()
             {
                 IsolationLevel = isolationLevel,
-                Timeout = _options.TransactionSynchronisationTimeout
+                Timeout = TransactionManager.MaximumTimeout
             };
 
             using (var transaction = new TransactionScope(scopeOption, transactionOptions))


### PR DESCRIPTION
This restores the previous tx timeout before the TransactionScope changes were introduced in 93e1f606.

See https://github.com/frankhommers/Hangfire.PostgreSql/issues/119 for context.