### PR TITLE
Enqueueing a job does not trigger a prepared transaction anymore when using transaction scope enlistment

### DIFF
--- a/src/Hangfire.PostgreSql/IPersistentJobQueue.cs
+++ b/src/Hangfire.PostgreSql/IPersistentJobQueue.cs
@@ -19,6 +19,7 @@
 //   
 //    Special thanks goes to him.
 
+using System.Data;
 using System.Threading;
 using Hangfire.Storage;
 
@@ -27,6 +28,6 @@ namespace Hangfire.PostgreSql
     public interface IPersistentJobQueue
     {
         IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken);
-        void Enqueue(string queue, string jobId);
+        void Enqueue(IDbConnection connection, string queue, string jobId);
     }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -229,14 +229,14 @@ RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fe
 				markJobAsFetched.Queue);
 		}
 
-		public void Enqueue(string queue, string jobId)
+		public void Enqueue(IDbConnection connection, string queue, string jobId)
 		{
 			string enqueueJobSql = @"
 INSERT INTO """ + _options.SchemaName + @""".""jobqueue"" (""jobid"", ""queue"") 
 VALUES (@jobId, @queue);
 ";
 
-			_storage.UseConnection(connection => connection.Execute(enqueueJobSql, new {jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue}));
+			connection.Execute(enqueueJobSql, new {jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue});
 		}
 
 		[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -169,7 +169,7 @@ VALUES (@jobId, @name, @reason, @createdAt, @data);
             var provider = _queueProviders.GetProvider(queue);
             var persistentQueue = provider.GetJobQueue();
 
-            QueueCommand((con) => persistentQueue.Enqueue(queue, jobId));
+            QueueCommand((con) => persistentQueue.Enqueue(con, queue, jobId));
         }
 
         public override void IncrementCounter(string key)

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -53,9 +53,9 @@ namespace Hangfire.PostgreSql.Tests
                 var queue = CreateJobQueue(storage, false);
                 var token = CreateTimingOutCancellationToken();
 
-                queue.Enqueue("1", "1");
-                queue.Enqueue("2", "2");
-                queue.Enqueue("3", "3");
+                queue.Enqueue(connection, "1", "1");
+                queue.Enqueue(connection, "2", "2");
+                queue.Enqueue(connection, "3", "3");
 
                 Assert.Equal("1", queue.Dequeue(new[] { "1", "2", "3" }, token).JobId);
                 Assert.Equal("2", queue.Dequeue(new[] { "2", "3", "1" }, token).JobId);
@@ -436,7 +436,7 @@ select i.""id"", @queue from i;
 
 				Assert.True(name.Length > 21);
 
-				queue.Enqueue(name, "1");
+				queue.Enqueue(connection, name, "1");
 
 				var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
 				Assert.Equal(name, record.queue.ToString());
@@ -449,7 +449,7 @@ select i.""id"", @queue from i;
 			{
 				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				queue.Enqueue("default", "1");
+				queue.Enqueue(connection, "default", "1");
 
 				var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
 				Assert.Equal("1", record.jobid.ToString());

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlWriteOnlyTransactionFacts.cs
@@ -266,7 +266,7 @@ returning ""id""";
 
                 Commit(sql, x => x.AddToQueue("default", "1"));
 
-                correctJobQueue.Verify(x => x.Enqueue("default", "1"));
+                correctJobQueue.Verify(x => x.Enqueue(sql, "default", "1"));
             });
         }
 


### PR DESCRIPTION
Fixes #158 

The issue can easily be fixed by passing a db connection to `PostgreSqlJobQueue.Enqueue`. The implementation is the same as in `Hangfire.SqlServer`. See [Hangfire.SqlServer/IPersistentJobQueue.cs](https://github.com/HangfireIO/Hangfire/blob/88af1e4c98fe1c1a24c21a99d350bc7f1ed7d575/src/Hangfire.SqlServer/IPersistentJobQueue.cs#L27) and [Hangfire.SqlServer/SqlServerJobQueue.cs](https://github.com/HangfireIO/Hangfire/blob/88af1e4c98fe1c1a24c21a99d350bc7f1ed7d575/src/Hangfire.SqlServer/SqlServerJobQueue.cs#L72).