### PR TITLE
Removed hangfire schema in Install.v13.sql

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v13.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v13.sql
@@ -11,4 +11,4 @@ BEGIN
 END
 $$;
 
-CREATE INDEX IF NOT EXISTS jobqueue_queue_fetchat_jobId ON hangfire.jobqueue USING btree (queue asc, fetchedat asc nulls last, jobid asc);
+CREATE INDEX IF NOT EXISTS jobqueue_queue_fetchat_jobId ON jobqueue USING btree (queue asc, fetchedat asc nulls last, jobid asc);


### PR DESCRIPTION
Remove the hardcoded "hangfire" schema to prevent errors when a custom schema is specified in .NET Core.
Fixes issue: https://github.com/frankhommers/Hangfire.PostgreSql/issues/173