### PR TITLE
Disappeared server restart fix

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -416,7 +416,12 @@ WHERE NOT EXISTS (
 				SET ""lastheartbeat"" = NOW() AT TIME ZONE 'UTC' 
 				WHERE ""id"" = @id;";
 
-			_connection.Execute(query, new { id = serverId });
+			int affectedRows = _connection.Execute(query, new { id = serverId });
+
+			if (affectedRows == 0)
+			{
+				throw new BackgroundServerGoneException();
+			}
 		}
 
 		public override int RemoveTimedOutServers(TimeSpan timeOut)

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
@@ -644,6 +644,15 @@ values ('Server1', '', now() at time zone 'utc'),
 		}
 
 		[Fact, CleanDatabase]
+		public void Heartbeat_ThrowsBackgroundServerGoneException_WhenServerDisappeared()
+		{
+			string disappearedServerId = Guid.NewGuid().ToString();
+
+			UseConnection(connection => Assert.Throws<BackgroundServerGoneException>(
+				() => connection.Heartbeat(disappearedServerId)));
+		}
+
+		[Fact, CleanDatabase]
 		public void Heartbeat_UpdatesLastHeartbeat_OfTheServerWithGivenId()
 		{
 			string arrangeSql = @"


### PR DESCRIPTION
This fix addresses https://github.com/frankhommers/Hangfire.PostgreSql/issues/167.

I also did some manual testing to make sure these changes work with Hangfire. I created a small ASPNET.Core app and configured Hangfire+Postgre with a single processing server. Then, I manually deleted all the records from `Server` table.

Here is the log output from Hangfire (since the moment when the server record was deleted):
```log
warn: Hangfire.Server.ServerHeartbeatProcess[0]
      Server desktop-4ma8jcd:13924:333a1381 was considered dead by other servers, restarting...
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:333a1381 caught restart signal...
warn: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:333a1381 stopped non-gracefully due to ServerWatchdog, ServerJobCancellationWatcher, ExpirationManager, Wo
rker, DelayedJobScheduler, RecurringJobScheduler. Outstanding work on those dispatchers could be aborted, and there can be delays in backgrou
nd processing. This server instance will be incorrectly shown as active for a while. To avoid non-graceful shutdowns, investigate what preven
ts from stopping gracefully and add CancellationToken support for those methods.
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop Worker:e7f04b49 stopped in 0,5281 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerHeartbeatProcess:0afbec87 stopped in 0,5352 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ExpirationManager:4be84ceb stopped in 0,6124 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop DelayedJobScheduler:6a51f539 stopped in 0,9001 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerWatchdog:c27b2b3e stopped in 1,6238 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerJobCancellationWatcher:8cb8c78c stopped in 1,7731 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop RecurringJobScheduler:18941d55 stopped in 1,866 ms
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:333a1381 successfully reported itself as stopped in 11,4265 ms
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:333a1381 has been stopped in total 14,2361 ms
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:246662e4 successfully announced in 13,2382 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerHeartbeatProcess:d63cb38e has started in 0,2873 ms
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:246662e4 is starting the registered dispatchers: ServerWatchdog, ServerJobCancellationWatcher, ExpirationM
anager, Worker, DelayedJobScheduler, RecurringJobScheduler...
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerWatchdog:543b614b has started in 3,6334 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ServerJobCancellationWatcher:0fbe30d5 has started in 7,1549 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop ExpirationManager:1a250bca has started in 2,3354 ms
dbug: Hangfire.PostgreSql.ExpirationManager[0]
      Removing outdated records from table 'counter'...
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop Worker:3311018a has started in 30,7352 ms
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop DelayedJobScheduler:fb768340 has started in 5,1145 ms
dbug: Hangfire.PostgreSql.ExpirationManager[0]
      Removing outdated records from table 'job'...
dbug: Hangfire.Processing.BackgroundExecution[0]
      Execution loop RecurringJobScheduler:3d489366 has started in 5,7748 ms
info: Hangfire.Server.BackgroundServerProcess[0]
      Server desktop-4ma8jcd:13924:246662e4 all the dispatchers started
dbug: Hangfire.PostgreSql.ExpirationManager[0]
      Removing outdated records from table 'list'...
dbug: Hangfire.PostgreSql.ExpirationManager[0]
      Removing outdated records from table 'set'...
dbug: Hangfire.PostgreSql.ExpirationManager[0]
      Removing outdated records from table 'hash'...
```

The running server instance is stopped and then started again. What I dislike about it is that it says `Server desktop-4ma8jcd:13924:333a1381 stopped non-gracefully`. But I tested the same scenario against `Hangfire.SqlServer` storage, and it behaved exactly the same.

I would like the server to be stopped gracefully, but I think it is Hangfire's responsibility, so we can't really do anything about it at this point.