### PR TITLE
Reset search_path in the end of every install script

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v10.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v10.sql
@@ -13,3 +13,5 @@ END
 $$;
 
 ALTER TABLE "jobqueue" ALTER COLUMN "queue" TYPE TEXT;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v11.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v11.sql
@@ -1,7 +1,5 @@
 SET search_path = 'hangfire';
 
-
-
 DO
 $$
 BEGIN
@@ -23,3 +21,5 @@ ALTER TABLE "jobqueue" ALTER COLUMN id TYPE BIGINT;
 ALTER TABLE "jobqueue" ALTER COLUMN jobid TYPE BIGINT;
 ALTER TABLE "list" ALTER COLUMN id TYPE BIGINT;
 ALTER TABLE "set" ALTER COLUMN id TYPE BIGINT;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v12.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v12.sql
@@ -1,7 +1,5 @@
 SET search_path = 'hangfire';
 
-
-
 DO
 $$
 BEGIN
@@ -21,3 +19,5 @@ ALTER TABLE "set" ALTER COLUMN "key" TYPE TEXT;
 ALTER TABLE "jobparameter" ALTER COLUMN "name" TYPE TEXT;
 ALTER TABLE "state" ALTER COLUMN "name" TYPE TEXT;
 ALTER TABLE "state" ALTER COLUMN reason TYPE TEXT;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v13.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v13.sql
@@ -12,3 +12,5 @@ END
 $$;
 
 CREATE INDEX IF NOT EXISTS jobqueue_queue_fetchat_jobId ON jobqueue USING btree (queue asc, fetchedat asc nulls last, jobid asc);
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v3.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v3.sql
@@ -201,3 +201,5 @@ $$;
 CREATE TABLE IF NOT EXISTS "lock" ( "resource" VARCHAR(100) NOT NULL ,
   UNIQUE ("resource")
 ); 
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v4.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v4.sql
@@ -22,3 +22,5 @@ ALTER TABLE "list" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
 ALTER TABLE "server" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
 ALTER TABLE "set" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
 ALTER TABLE "state" ADD COLUMN "updatecount" integer NOT NULL DEFAULT 0;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v5.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v5.sql
@@ -13,3 +13,5 @@ END
 $$;
 
 ALTER TABLE "server" ALTER COLUMN "id" TYPE VARCHAR(100);
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v6.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v6.sql
@@ -33,3 +33,4 @@ BEGIN
 END;
 $$;
 
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v7.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v7.sql
@@ -13,3 +13,5 @@ END
 $$;
 
 ALTER TABLE "lock" ADD COLUMN acquired timestamp without time zone;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v8.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v8.sql
@@ -14,3 +14,5 @@ $$;
 
 ALTER TABLE "counter" ALTER COLUMN value TYPE bigint;
 ALTER TABLE "counter" DROP COLUMN updatecount RESTRICT;
+
+RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v9.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v9.sql
@@ -13,3 +13,5 @@ END
 $$;
 
 ALTER TABLE "lock" ALTER COLUMN "resource" TYPE TEXT;
+
+RESET search_path;


### PR DESCRIPTION
This fix addresses #109.

Resetting search_path in the end of every install script to prevent errors with connection re-using in connection pools.