### PR TITLE
Revert (accidental?) change that prevents Install.v14.sql from succeeding

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v14.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v14.sql
@@ -13,9 +13,9 @@ do
 $$
 DECLARE
 BEGIN
- 	EXECUTE('ALTER SEQUENCE ' || 'hangfire' || '.job_id_seq MAXVALUE 9223372036854775807');
+ 	EXECUTE('ALTER SEQUENCE ' || 'hangfire' || '.job_id_seq AS bigint MAXVALUE 9223372036854775807');
 EXCEPTION WHEN syntax_error THEN
-	EXECUTE('ALTER SEQUENCE ' || 'hangfire' || '.job_id_seq AS bigint MAXVALUE 9223372036854775807');
+	EXECUTE('ALTER SEQUENCE ' || 'hangfire' || '.job_id_seq MAXVALUE 9223372036854775807');
 END;
 $$;
 


### PR DESCRIPTION
Hello,

## Overview
Reverts the installer script change made (accidentally?) during https://github.com/frankhommers/Hangfire.PostgreSql/commit/0c48d67066fe1c38d45bbc632db98aba8df9bd09

## Problem
As others reported, I am also seeing `22023: MAXVALUE (9223372036854775807) is out of range for sequence data type integer `  during schema update as per https://github.com/frankhommers/Hangfire.PostgreSql/issues/201

Importantly, the column is NOT moved to `bigint` and this schema `v14` is not applied (and fails again on next startup).

Was it intentional that the order of begin/exception statements changed in "version bump" commit at https://github.com/frankhommers/Hangfire.PostgreSql/commit/0c48d67066fe1c38d45bbc632db98aba8df9bd09 ?

Under pg13.x the first `ALTER SEQUENCE hangfire.job_id_seq MAXVALUE 9223372036854775807` statement fails _not_ with `syntax error` but `invalid_parameter_value` error, which is not caught, so the migration rollsback and fails to be retried again later.

I think the previous logic of first trying `ALTER SEQUENCE hangfire.job_id_seq AS bigint MAXVALUE 9223372036854775807` which succeeds under pg13, but assumedly fails with a syntax error under older versions (to be caught as `syntax_error`) is intended, and the above version bump commit mistakenly switched the order?

## Fix
My suggested fix is to put the ordering back how you it was originally (edit this existing migration inline) so that it can be applied correctly going forward.

## Reproduction
```csharp
using System;
using Hangfire;
using Hangfire.Logging;
using Hangfire.Logging.LogProviders;
using Hangfire.PostgreSql;

namespace hangfire_pg_test
{
	class Program
	{
		static void Main(string[] args)
		{
			// Turn on logging to console
			LogProvider.SetCurrentLogProvider(new ColouredConsoleLogProvider());

			// Set connection string
			var connStr = args[0];

			// Start hangfire server
			var server = new BackgroundJobServer(new BackgroundJobServerOptions(), new PostgreSqlStorage(connStr));

			// Should have applied migrations by now
			Console.WriteLine("Should have applied migrations without error by now");
		}
	}
}

// Usage:
dotnet run "Username=postgres;Password=xxx;Database=hangfire_test;Host=localhost;";
```

Result:
```
2021-07-14 06:27:42 [INFO]  (Hangfire.PostgreSql.PostgreSqlStorage) Start installing Hangfire SQL objects...
2021-07-14 06:27:42 [ERROR] (Hangfire.PostgreSql.PostgreSqlStorage) Error while executing install/upgrade
Npgsql.PostgresException
22023: MAXVALUE (9223372036854775807) is out of range for sequence data type integer
   at Npgsql.NpgsqlConnector.<ReadMessage>g__ReadMessageLong|194_0(NpgsqlConnector connector, Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isReadingPrependedMessage)
   at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming, CancellationToken cancellationToken)
   at Npgsql.NpgsqlDataReader.NextResult()
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteNonQuery(Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteNonQuery()
   at Hangfire.PostgreSql.PostgreSqlObjectsInstaller.Install(NpgsqlConnection connection, String schemaName)
2021-07-14 06:27:42 [INFO]  (Hangfire.PostgreSql.PostgreSqlStorage) Hangfire SQL objects installed.
```

Thank you
Andrew