### PR TITLE
Improve ExpirationManager performance and options

### DIFF
--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -56,7 +56,7 @@ namespace Hangfire.PostgreSql
         private readonly TimeSpan _checkInterval;
 
         public ExpirationManager(PostgreSqlStorage storage, PostgreSqlStorageOptions options)
-            : this(storage, options, TimeSpan.FromHours(1))
+            : this(storage, options, options.JobExpirationCheckInterval)
         {
         }
 

--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -32,7 +32,6 @@ namespace Hangfire.PostgreSql
     internal class ExpirationManager : IBackgroundProcess, IServerComponent
     {
         private static readonly TimeSpan DelayBetweenPasses = TimeSpan.FromSeconds(1);
-        private const int NumberOfRecordsInSinglePass = 1000;
 
         private static readonly ILog Logger = LogProvider.GetLogger(typeof(ExpirationManager));
 
@@ -93,7 +92,7 @@ WHERE ""id"" IN (
     FROM """ + _options.SchemaName + @""".""{0}"" 
     WHERE ""expireat"" < NOW() AT TIME ZONE 'UTC' 
     LIMIT {1}
-)", table, NumberOfRecordsInSinglePass.ToString(CultureInfo.InvariantCulture)), transaction);
+)", table, _options.DeleteExpiredBatchSize.ToString(CultureInfo.InvariantCulture)), transaction);
 
                             transaction.Commit();
                         }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -30,6 +30,7 @@ namespace Hangfire.PostgreSql
         private TimeSpan _distributedLockTimeout;
         private TimeSpan _transactionSerializationTimeout;
         private TimeSpan _jobExpirationCheckInterval;
+        private int _deleteExpiredBatchSize;
 
         public PostgreSqlStorageOptions()
         {
@@ -41,6 +42,7 @@ namespace Hangfire.PostgreSql
             SchemaName = "hangfire";
             UseNativeDatabaseTransactions = true;
             PrepareSchemaIfNecessary = true;
+            DeleteExpiredBatchSize = 1000;
         }
 
         public TimeSpan QueuePollInterval
@@ -93,7 +95,20 @@ namespace Hangfire.PostgreSql
 			}
 		}
 
-        public bool UseNativeDatabaseTransactions { get; set; }
+		/// <summary>
+		/// Gets or sets the number of records deleted in a single batch in expiration manager
+		/// </summary>
+		public int DeleteExpiredBatchSize
+		{
+			get => _deleteExpiredBatchSize;
+			set 
+			{
+				ThrowIfValueIsNotPositive(value, nameof(DeleteExpiredBatchSize));
+                _deleteExpiredBatchSize = value;
+			}
+		}
+
+		public bool UseNativeDatabaseTransactions { get; set; }
         public bool PrepareSchemaIfNecessary { get; set; }
         public string SchemaName { get; set; }
         public bool EnableTransactionScopeEnlistment { get; set; }
@@ -110,6 +125,12 @@ namespace Hangfire.PostgreSql
             {
                 throw new ArgumentException(message, nameof(value));
             }
+        }
+
+        private static void ThrowIfValueIsNotPositive(int value, string fieldName)
+        {
+            if (value < 0)
+		        throw new ArgumentException($"The {fieldName} property value should be positive. Given: {value}.");
         }
     }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -129,7 +129,7 @@ namespace Hangfire.PostgreSql
 
         private static void ThrowIfValueIsNotPositive(int value, string fieldName)
         {
-            if (value < 0)
+            if (value <= 0)
 		        throw new ArgumentException($"The {fieldName} property value should be positive. Given: {value}.");
         }
     }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -29,6 +29,7 @@ namespace Hangfire.PostgreSql
         private TimeSpan _invisibilityTimeout;
         private TimeSpan _distributedLockTimeout;
         private TimeSpan _transactionSerializationTimeout;
+        private TimeSpan _jobExpirationCheckInterval;
 
         public PostgreSqlStorageOptions()
         {
@@ -36,6 +37,7 @@ namespace Hangfire.PostgreSql
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
             DistributedLockTimeout = TimeSpan.FromMinutes(10);
 	        TransactionSynchronisationTimeout = TimeSpan.FromMilliseconds(500);
+	        JobExpirationCheckInterval = TimeSpan.FromHours(1);
             SchemaName = "hangfire";
             UseNativeDatabaseTransactions = true;
             PrepareSchemaIfNecessary = true;
@@ -79,6 +81,16 @@ namespace Hangfire.PostgreSql
 			    ThrowIfValueIsNotPositive(value, nameof(TransactionSynchronisationTimeout));
 			    _transactionSerializationTimeout = value;
 		    }
+		}
+
+		public TimeSpan JobExpirationCheckInterval
+		{
+			get => _jobExpirationCheckInterval;
+			set
+			{
+				ThrowIfValueIsNotPositive(value, nameof(JobExpirationCheckInterval));
+				_jobExpirationCheckInterval = value;
+			}
 		}
 
         public bool UseNativeDatabaseTransactions { get; set; }

--- a/src/Hangfire.PostgreSql/Scripts/Install.v15.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v15.sql
@@ -1,0 +1,17 @@
+SET search_path = 'hangfire';
+
+DO
+$$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "schema" WHERE "version"::integer >= 15) THEN
+    RAISE EXCEPTION 'version-already-applied';
+  END IF;
+END
+$$;
+
+CREATE INDEX ix_hangfire_job_expireat ON "job" (expireat);
+CREATE INDEX ix_hangfire_list_expireat ON "list" (expireat);
+CREATE INDEX ix_hangfire_set_expireat ON "set" (expireat);
+CREATE INDEX ix_hangfire_hash_expireat ON "hash" (expireat);
+
+RESET search_path;

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
@@ -20,7 +20,7 @@ namespace Hangfire.PostgreSql.Tests
 					PostgreSqlObjectsInstaller.Install(connection, schemaName);
 
 					var lastVersion = connection.Query<int>(@"select version from """ + schemaName + @""".""schema""").Single();
-					Assert.Equal(14, lastVersion);
+					Assert.Equal(15, lastVersion);
 
 					connection.Execute($@"DROP SCHEMA ""{schemaName}"" CASCADE;");
 				});


### PR DESCRIPTION
## Overview
This PR addresses #193 and #194 by exposing two new `PostgresStorageOptions` properties, and adding missing indexes to help with the expiration queries performance in `ExpirationManager`.

`PostgresStorageOptions` now supports:
1. `JobExpirationCheckInterval`: How often expiration of expired job resources are cleaned up (defaults to existing value of 1 hour)
2. `DeleteExpiredBatchSize`: How many records may be deleted per batch run of the expiration manager (defaults to existing value of 1000)

New indexes have also been added to `job, list, set, hash` on the `expireat` column to help with the `ExpirationManager` delete query performance mentioned in #194 . The `counter` table that is also part of the expiration cleanup already has an index on `expireat`.