### PR TITLE
Fixes for post-merge of recent PR #189

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -45,23 +45,20 @@ namespace Hangfire.PostgreSql
 			_storage = storage ?? throw new ArgumentNullException(nameof(storage));
 			SignalDequeue = new AutoResetEvent(false);
 		}
-        public PostgreSqlJobQueue(PostgreSqlStorage storage, PostgreSqlStorageOptions options)
-        {
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-        }
 
+		[NotNull]
+		public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
+		{
+			if (_options.UseNativeDatabaseTransactions)
+				return Dequeue_Transaction(queues, cancellationToken);
 
-        [NotNull]
-        public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
-        {
-            if (_options.UseNativeDatabaseTransactions)
-                return Dequeue_Transaction(queues, cancellationToken);
+			return Dequeue_UpdateCount(queues, cancellationToken);
+		}
 
-		/// <summary>
-		///		Signal the waiting Thread to lookup a new Job
-		/// </summary>
-		public void FetchNextJob()
+        /// <summary>
+        ///		Signal the waiting Thread to lookup a new Job
+        /// </summary>
+        public void FetchNextJob()
 		{
 			SignalDequeue.Set();
 		}

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -230,7 +230,13 @@ RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fe
                 {
                     if (currentQueryIndex == fetchConditions.Length - 1)
                     {
-                        cancellationToken.WaitHandle.WaitOne(_options.QueuePollInterval);
+	                    WaitHandle.WaitAny(new[]
+		                    {
+			                    cancellationToken.WaitHandle,
+			                    SignalDequeue
+		                    },
+		                    _options.QueuePollInterval);
+
                         cancellationToken.ThrowIfCancellationRequested();
                     }
                 }


### PR DESCRIPTION
This PR addresses some post-merge issues of PR #189 

1. Fixed compilation error (seems GitHub merged incorrectly)
2. Fixed the added test not passing if `options.UseNativeDatabaseTransactions` was in use (seems to be, for `dotnet test` environment)