### PR TITLE
Fix SQL connection pool exhaustion issues

### DIFF
--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -19,18 +19,22 @@
 //   
 //    Special thanks goes to him.
 
+using Dapper;
+using Hangfire.Logging;
+using Hangfire.Server;
+using Hangfire.Storage;
 using System;
 using System.Data;
 using System.Globalization;
 using System.Threading;
-using Dapper;
-using Hangfire.Logging;
-using Hangfire.Server;
 
 namespace Hangfire.PostgreSql
 {
     internal class ExpirationManager : IBackgroundProcess, IServerComponent
     {
+        private const string DistributedLockKey = "locks:expirationmanager";
+        private static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromMinutes(5);
+
         private static readonly TimeSpan DelayBetweenPasses = TimeSpan.FromSeconds(1);
         private const int NumberOfRecordsInSinglePass = 1000;
 
@@ -52,18 +56,16 @@ namespace Hangfire.PostgreSql
         };
 
         private readonly PostgreSqlStorage _storage;
-        private readonly PostgreSqlStorageOptions _options;
         private readonly TimeSpan _checkInterval;
 
-        public ExpirationManager(PostgreSqlStorage storage, PostgreSqlStorageOptions options)
-            : this(storage, options, TimeSpan.FromHours(1))
+        public ExpirationManager(PostgreSqlStorage storage)
+            : this(storage, TimeSpan.FromHours(1))
         {
         }
 
-        public ExpirationManager(PostgreSqlStorage storage, PostgreSqlStorageOptions options, TimeSpan checkInterval)
+        public ExpirationManager(PostgreSqlStorage storage, TimeSpan checkInterval)
         {
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
             _checkInterval = checkInterval;
         }
 
@@ -81,33 +83,34 @@ namespace Hangfire.PostgreSql
 
                 do
                 {
-                    using (var storageConnection = (PostgreSqlConnection)_storage.GetConnection())
+                    UseConnectionDistributedLock(_storage, connection =>
                     {
-                        using (var transaction = storageConnection.Connection.BeginTransaction(IsolationLevel.ReadCommitted))
+                        using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
                         {
-                            removedCount = storageConnection.Connection.Execute(
+                            removedCount = connection.Execute(
                                 string.Format(@"
-DELETE FROM """ + _options.SchemaName + @""".""{0}"" 
+DELETE FROM """ + _storage.Options.SchemaName + @""".""{0}"" 
 WHERE ""id"" IN (
     SELECT ""id"" 
-    FROM """ + _options.SchemaName + @""".""{0}"" 
+    FROM """ + _storage.Options.SchemaName + @""".""{0}"" 
     WHERE ""expireat"" < NOW() AT TIME ZONE 'UTC' 
     LIMIT {1}
 )", table, NumberOfRecordsInSinglePass.ToString(CultureInfo.InvariantCulture)), transaction);
 
                             transaction.Commit();
                         }
-                    }
 
-                    if (removedCount > 0)
-                    {
-                        Logger.InfoFormat("Removed {0} outdated record(s) from '{1}' table.", removedCount, table);
+                        if (removedCount > 0)
+                        {
+                            Logger.InfoFormat("Removed {0} outdated record(s) from '{1}' table.", removedCount, table);
 
-                        cancellationToken.WaitHandle.WaitOne(DelayBetweenPasses);
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                            cancellationToken.WaitHandle.WaitOne(DelayBetweenPasses);
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+                    });
                 } while (removedCount != 0);
             }
+
             AggregateCounters(cancellationToken);
             cancellationToken.WaitHandle.WaitOne(_checkInterval);
         }
@@ -123,13 +126,13 @@ WHERE ""id"" IN (
 
         private void AggregateCounter(string counterName)
         {
-            using (var connection = (PostgreSqlConnection)_storage.GetConnection())
+            UseConnectionDistributedLock(_storage, connection =>
             {
-                using (var transaction = connection.Connection.BeginTransaction(IsolationLevel.ReadCommitted))
+                using (var transaction = connection.BeginTransaction(IsolationLevel.ReadCommitted))
                 {
                     var aggregateQuery = $@"
 WITH counters AS (
-DELETE FROM ""{_options.SchemaName}"".""counter""
+DELETE FROM ""{_storage.Options.SchemaName}"".""counter""
 WHERE ""key"" = '{counterName}'
 AND ""expireat"" IS NULL
 RETURNING *
@@ -138,15 +141,44 @@ RETURNING *
 SELECT SUM(value) FROM counters;
 ";
 
-                    var aggregatedValue = connection.Connection.ExecuteScalar<long>(aggregateQuery, transaction: transaction);
+                    var aggregatedValue = connection.ExecuteScalar<long>(aggregateQuery, transaction: transaction);
                     transaction.Commit();
 
                     if (aggregatedValue > 0)
                     {
-                        var insertQuery = $@"INSERT INTO ""{_options.SchemaName}"".""counter""(""key"", ""value"") VALUES (@key, @value);";
-                        connection.Connection.Execute(insertQuery, new { key = counterName, value = aggregatedValue });
+                        var insertQuery = $@"INSERT INTO ""{_storage.Options.SchemaName}"".""counter""(""key"", ""value"") VALUES (@key, @value);";
+                        connection.Execute(insertQuery, new { key = counterName, value = aggregatedValue });
                     }
                 }
+            });
+        }
+
+        private void UseConnectionDistributedLock(PostgreSqlStorage storage, Action<IDbConnection> action)
+        {
+            try
+            {
+                storage.UseConnection(null, connection =>
+                {
+                    PostgreSqlDistributedLock.Acquire(connection, DistributedLockKey, DefaultLockTimeout, _storage.Options);
+
+                    try
+                    {
+                        action(connection);
+                    }
+                    finally
+                    {
+                        PostgreSqlDistributedLock.Release(connection, DistributedLockKey, _storage.Options);
+                    }
+                });
+            }
+            catch (DistributedLockTimeoutException e) when (e.Resource == DistributedLockKey)
+            {
+                // DistributedLockTimeoutException here doesn't mean that outdated records weren't removed.
+                // It just means another Hangfire server did this work.
+                Logger.Log(
+                    LogLevel.Debug,
+                    () => $@"An exception was thrown during acquiring distributed lock on the {DistributedLockKey} resource within {DefaultLockTimeout.TotalSeconds} seconds. Outdated records were not removed. It will be retried in {_checkInterval.TotalSeconds} seconds.",
+                    e);
             }
         }
     }

--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -58,7 +58,7 @@ namespace Hangfire.PostgreSql
         private readonly TimeSpan _checkInterval;
 
         public ExpirationManager(PostgreSqlStorage storage)
-            : this(storage, storage.Options.JobExpirationCheckInterval)
+            : this(storage ?? throw new ArgumentNullException(nameof(storage)), storage.Options.JobExpirationCheckInterval)
         {
         }
 

--- a/src/Hangfire.PostgreSql/PersistentJobQueueProviderCollection.cs
+++ b/src/Hangfire.PostgreSql/PersistentJobQueueProviderCollection.cs
@@ -28,7 +28,7 @@ namespace Hangfire.PostgreSql
     public class PersistentJobQueueProviderCollection : IEnumerable<IPersistentJobQueueProvider>
     {
         private readonly List<IPersistentJobQueueProvider> _providers
-            = new List<IPersistentJobQueueProvider>(); 
+            = new List<IPersistentJobQueueProvider>();
         private readonly Dictionary<string, IPersistentJobQueueProvider> _providersByQueue
             = new Dictionary<string, IPersistentJobQueueProvider>(StringComparer.OrdinalIgnoreCase);
 
@@ -36,7 +36,7 @@ namespace Hangfire.PostgreSql
 
         public PersistentJobQueueProviderCollection(IPersistentJobQueueProvider defaultProvider)
         {
-	        _defaultProvider = defaultProvider ?? throw new ArgumentNullException(nameof(defaultProvider));
+            _defaultProvider = defaultProvider ?? throw new ArgumentNullException(nameof(defaultProvider));
             _providers.Add(_defaultProvider);
         }
 
@@ -55,9 +55,18 @@ namespace Hangfire.PostgreSql
 
         public IPersistentJobQueueProvider GetProvider(string queue)
         {
-            return _providersByQueue.ContainsKey(queue) 
+            return _providersByQueue.ContainsKey(queue)
                 ? _providersByQueue[queue]
                 : _defaultProvider;
+        }
+
+        public void Remove(string queue)
+        {
+            if (!_providersByQueue.ContainsKey(queue)) return;
+
+            var provider = _providersByQueue[queue];
+            _providersByQueue.Remove(queue);
+            _providers.Remove(provider);
         }
 
         public IEnumerator<IPersistentJobQueueProvider> GetEnumerator()

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -19,218 +19,213 @@
 //   
 //    Special thanks goes to him.
 
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
-using System.Globalization;
-using System.Linq;
-using System.Threading;
 using Dapper;
 using Hangfire.Common;
 using Hangfire.PostgreSql.Entities;
 using Hangfire.Server;
 using Hangfire.Storage;
 using Npgsql;
-using Hangfire.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
 
 namespace Hangfire.PostgreSql
 {
-	public class PostgreSqlConnection : JobStorageConnection
-	{
-		private readonly NpgsqlConnection _connection;
-		private readonly PersistentJobQueueProviderCollection _queueProviders;
-		private readonly PostgreSqlStorageOptions _options;
+    public class PostgreSqlConnection : JobStorageConnection
+    {
+        private readonly PostgreSqlStorage _storage;
+        private readonly PostgreSqlStorageOptions _options;
+        private readonly Dictionary<string, HashSet<Guid>> _lockedResources;
 
-		public PostgreSqlConnection(
-			NpgsqlConnection connection,
-			PersistentJobQueueProviderCollection queueProviders,
-			PostgreSqlStorageOptions options)
-			: this(connection, queueProviders, options, true)
-		{
-		}
+        public PostgreSqlConnection(PostgreSqlStorage storage)
+        {
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            _options = storage.Options ?? throw new ArgumentNullException(nameof(storage.Options));
+            _lockedResources = new Dictionary<string, HashSet<Guid>>();
+        }
 
-		public PostgreSqlConnection(
-			NpgsqlConnection connection,
-			PersistentJobQueueProviderCollection queueProviders,
-			PostgreSqlStorageOptions options,
-			bool ownsConnection)
-		{
-			_connection = connection ?? throw new ArgumentNullException(nameof(connection));
-			_queueProviders = queueProviders ?? throw new ArgumentNullException(nameof(queueProviders));
-			_options = options ?? throw new ArgumentNullException(nameof(options));
-			OwnsConnection = ownsConnection;
-		}
+        public override void Dispose()
+        {
+            if (_dedicatedConnection != null)
+            {
+                _dedicatedConnection.Dispose();
+                _dedicatedConnection = null;
+            }
+        }
 
-		public bool OwnsConnection { get; private set; }
-		public NpgsqlConnection Connection => _connection;
+        public override IWriteOnlyTransaction CreateWriteTransaction()
+        {
+            return new PostgreSqlWriteOnlyTransaction(_storage, () => _dedicatedConnection);
+        }
 
-		public override void Dispose()
-		{
-            base.Dispose();
-			if (OwnsConnection)
-			{
-				_connection.Dispose();
-			}
-		}
+        public override IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)
+        {
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentNullException(nameof(resource));
+            }
 
-		public override IWriteOnlyTransaction CreateWriteTransaction()
-		{
-			return new PostgreSqlWriteOnlyTransaction(_connection, _options, _queueProviders);
-		}
+            return AcquireLock($"{_options.SchemaName}:{resource}", timeout);
+        }
 
-		public override IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)
-		{
-			return new PostgreSqlDistributedLock(
-				$"HangFire:{resource}",
-				timeout,
-				_connection,
-				_options);
-		}
+        public override IFetchedJob FetchNextJob(string[] queues, CancellationToken cancellationToken)
+        {
+            if (queues == null || queues.Length == 0) throw new ArgumentNullException(nameof(queues));
 
-		public override IFetchedJob FetchNextJob(string[] queues, CancellationToken cancellationToken)
-		{
-			if (queues == null || queues.Length == 0) throw new ArgumentNullException(nameof(queues));
+            var providers = queues
+                .Select(queue => _storage.QueueProviders.GetProvider(queue))
+                .Distinct()
+                .ToArray();
 
-			var providers = queues
-				.Select(queue => _queueProviders.GetProvider(queue))
-				.Distinct()
-				.ToArray();
+            if (providers.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Multiple provider instances registered for queues: {String.Join(", ", queues)}. You should choose only one type of persistent queues per server instance.");
+            }
 
-			if (providers.Length != 1)
-			{
-				throw new InvalidOperationException(
-					$"Multiple provider instances registered for queues: {String.Join(", ", queues)}. You should choose only one type of persistent queues per server instance.");
-			}
+            var persistentQueue = providers[0].GetJobQueue();
+            return persistentQueue.Dequeue(queues, cancellationToken);
+        }
 
-			var persistentQueue = providers[0].GetJobQueue();
-			return persistentQueue.Dequeue(queues, cancellationToken);
-		}
+        public override string CreateExpiredJob(
+            Job job,
+            IDictionary<string, string> parameters,
+            DateTime createdAt,
+            TimeSpan expireIn)
+        {
+            if (job == null) throw new ArgumentNullException(nameof(job));
+            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
 
-		public override string CreateExpiredJob(
-			Job job,
-			IDictionary<string, string> parameters,
-			DateTime createdAt,
-			TimeSpan expireIn)
-		{
-			if (job == null) throw new ArgumentNullException(nameof(job));
-			if (parameters == null) throw new ArgumentNullException(nameof(parameters));
-
-			string createJobSql = @"
+            string createJobSql = @"
 INSERT INTO """ + _options.SchemaName + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"", ""expireat"")
 VALUES (@invocationData, @arguments, @createdAt, @expireAt) 
 RETURNING ""id"";
 ";
 
-			var invocationData = InvocationData.SerializeJob(job);
+            var invocationData = InvocationData.SerializeJob(job);
 
-			var jobId = _connection.Query<long>(
-				createJobSql,
-				new
-				{
-					invocationData = SerializationHelper.Serialize(invocationData),
-					arguments = invocationData.Arguments,
-					createdAt = createdAt,
-					expireAt = createdAt.Add(expireIn)
-				}).Single().ToString(CultureInfo.InvariantCulture);
+            return _storage.UseConnection(_dedicatedConnection, connection =>
+            {
+                var jobId = connection.Query<long>(
+                    createJobSql,
+                    new
+                    {
+                        invocationData = SerializationHelper.Serialize(invocationData),
+                        arguments = invocationData.Arguments,
+                        createdAt = createdAt,
+                        expireAt = createdAt.Add(expireIn)
+                    }).Single().ToString(CultureInfo.InvariantCulture);
 
-			if (parameters.Count > 0)
-			{
-				var parameterArray = new object[parameters.Count];
-				int parameterIndex = 0;
-				foreach (var parameter in parameters)
-				{
-					parameterArray[parameterIndex++] = new
-					{
-						jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture),
-						name = parameter.Key,
-						value = parameter.Value
-					};
-				}
+                if (parameters.Count > 0)
+                {
+                    var parameterArray = new object[parameters.Count];
+                    int parameterIndex = 0;
+                    foreach (var parameter in parameters)
+                    {
+                        parameterArray[parameterIndex++] = new
+                        {
+                            jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture),
+                            name = parameter.Key,
+                            value = parameter.Value
+                        };
+                    }
 
-				string insertParameterSql = @"
+                    string insertParameterSql = @"
 INSERT INTO """ + _options.SchemaName + @""".""jobparameter"" (""jobid"", ""name"", ""value"")
 VALUES (@jobId, @name, @value);
 ";
 
-				_connection.Execute(insertParameterSql, parameterArray);
-			}
+                    connection.Execute(insertParameterSql, parameterArray);
+                }
 
-			return jobId;
-		}
+                return jobId;
+            });
+        }
 
-		public override JobData GetJobData(string id)
-		{
-			if (id == null) throw new ArgumentNullException(nameof(id));
+        public override JobData GetJobData(string id)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
 
-			string sql =
-				@"
+            string sql =
+                @"
 SELECT ""invocationdata"" ""invocationData"", ""statename"" ""stateName"", ""arguments"", ""createdat"" ""createdAt"" 
 FROM """ + _options.SchemaName + @""".""job"" 
 WHERE ""id"" = @id;
 ";
 
-			var jobData = _connection.Query<SqlJob>(sql, new { id = Convert.ToInt32(id, CultureInfo.InvariantCulture) })
-				.SingleOrDefault();
+            var jobData = _storage.UseConnection(
+                _dedicatedConnection,
+                connection => connection
+                    .Query<SqlJob>(sql, new { id = Convert.ToInt32(id, CultureInfo.InvariantCulture) })
+                    .SingleOrDefault());
 
-			if (jobData == null) return null;
+            if (jobData == null) return null;
 
-			// TODO: conversion exception could be thrown.
-			var invocationData = SerializationHelper.Deserialize<InvocationData>(jobData.InvocationData);
-			invocationData.Arguments = jobData.Arguments;
+            // TODO: conversion exception could be thrown.
+            var invocationData = SerializationHelper.Deserialize<InvocationData>(jobData.InvocationData);
+            invocationData.Arguments = jobData.Arguments;
 
-			Job job = null;
-			JobLoadException loadException = null;
+            Job job = null;
+            JobLoadException loadException = null;
 
-			try
-			{
-				job = invocationData.DeserializeJob();
-			}
-			catch (JobLoadException ex)
-			{
-				loadException = ex;
-			}
+            try
+            {
+                job = invocationData.DeserializeJob();
+            }
+            catch (JobLoadException ex)
+            {
+                loadException = ex;
+            }
 
-			return new JobData
-			{
-				Job = job,
-				State = jobData.StateName,
-				CreatedAt = jobData.CreatedAt,
-				LoadException = loadException
-			};
-		}
+            return new JobData
+            {
+                Job = job,
+                State = jobData.StateName,
+                CreatedAt = jobData.CreatedAt,
+                LoadException = loadException
+            };
+        }
 
-		public override StateData GetStateData(string jobId)
-		{
-			if (jobId == null) throw new ArgumentNullException(nameof(jobId));
+        public override StateData GetStateData(string jobId)
+        {
+            if (jobId == null) throw new ArgumentNullException(nameof(jobId));
 
-			string sql = @"
+            string sql = @"
 SELECT s.""name"" ""Name"", s.""reason"" ""Reason"", s.""data"" ""Data""
 FROM """ + _options.SchemaName + @""".""state"" s
 INNER JOIN """ + _options.SchemaName + @""".""job"" j on j.""stateid"" = s.""id""
 WHERE j.""id"" = @jobId;
 ";
 
-			var sqlState = _connection.Query<SqlState>(sql, new { jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture) }).SingleOrDefault();
-			if (sqlState == null)
-			{
-				return null;
-			}
+            var sqlState = _storage.UseConnection(
+                _dedicatedConnection,
+                connection => connection
+                    .Query<SqlState>(sql, new { jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture) })
+                    .SingleOrDefault());
+            if (sqlState == null)
+            {
+                return null;
+            }
 
-			return new StateData
-			{
-				Name = sqlState.Name,
-				Reason = sqlState.Reason,
-				Data = SerializationHelper.Deserialize<Dictionary<string, string>>(sqlState.Data)
-			};
-		}
+            return new StateData
+            {
+                Name = sqlState.Name,
+                Reason = sqlState.Reason,
+                Data = SerializationHelper.Deserialize<Dictionary<string, string>>(sqlState.Data)
+            };
+        }
 
-		public override void SetJobParameter(string id, string name, string value)
-		{
-			if (id == null) throw new ArgumentNullException(nameof(id));
-			if (name == null) throw new ArgumentNullException(nameof(name));
+        public override void SetJobParameter(string id, string name, string value)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
-			string sql = @"
+            string sql = @"
 WITH ""inputvalues"" AS (
 	SELECT @jobid ""jobid"", @name ""name"", @value ""value""
 ), ""updatedrows"" AS ( 
@@ -251,57 +246,59 @@ WHERE NOT EXISTS (
 	AND ""updatedrows"".""name"" = ""insertvalues"".""name""
 );";
 
-			_connection.Execute(sql,
-				new { jobId = Convert.ToInt32(id, CultureInfo.InvariantCulture), name, value });
-		}
+            _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Execute(sql, new { jobId = Convert.ToInt32(id, CultureInfo.InvariantCulture), name, value }));
+        }
 
-		public override string GetJobParameter(string id, string name)
-		{
-			if (id == null) throw new ArgumentNullException(nameof(id));
-			if (name == null) throw new ArgumentNullException(nameof(name));
+        public override string GetJobParameter(string id, string name)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
-			string query = $@"SELECT ""value"" FROM ""{_options.SchemaName}"".""jobparameter"" WHERE ""jobid"" = @id AND ""name"" = @name;
-";
+            string query = $@"SELECT ""value"" FROM ""{_options.SchemaName}"".""jobparameter"" WHERE ""jobid"" = @id AND ""name"" = @name;";
 
-			return _connection.Query<string>(query,
-				new { id = Convert.ToInt32(id, CultureInfo.InvariantCulture), name = name })
-				.SingleOrDefault();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(query, new { id = Convert.ToInt32(id, CultureInfo.InvariantCulture), name = name })
+                .SingleOrDefault());
+        }
 
-		public override HashSet<string> GetAllItemsFromSet(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override HashSet<string> GetAllItemsFromSet(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"SELECT ""value"" FROM ""{_options.SchemaName}"".""set"" WHERE ""key"" = @key;";
+            string query = $@"SELECT ""value"" FROM ""{_options.SchemaName}"".""set"" WHERE ""key"" = @key;";
 
-			var result = _connection.Query<string>(query, new { key });
+            return _storage.UseConnection(_dedicatedConnection, connection =>
+            {
+                var result = connection.Query<string>(query, new { key });
 
-			return new HashSet<string>(result);
-		}
+                return new HashSet<string>(result);
+            });
+        }
 
-		public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
-			if (toScore < fromScore) throw new ArgumentException("The `toScore` value must be higher or equal to the `fromScore` value.");
+        public override string GetFirstByLowestScoreFromSet(string key, double fromScore, double toScore)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (toScore < fromScore) throw new ArgumentException("The `toScore` value must be higher or equal to the `fromScore` value.");
 
-			return _connection.Query<string>(
-				@"
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(@"
 SELECT ""value"" 
 FROM """ + _options.SchemaName + @""".""set"" 
 WHERE ""key"" = @key 
 AND ""score"" BETWEEN @from AND @to 
 ORDER BY ""score"" LIMIT 1;
 ",
-				new { key, from = fromScore, to = toScore })
-				.SingleOrDefault();
-		}
+                    new { key, from = fromScore, to = toScore })
+                .SingleOrDefault());
+        }
 
-		public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
-			if (keyValuePairs == null) throw new ArgumentNullException(nameof(keyValuePairs));
+        public override void SetRangeInHash(string key, IEnumerable<KeyValuePair<string, string>> keyValuePairs)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (keyValuePairs == null) throw new ArgumentNullException(nameof(keyValuePairs));
 
-			string sql = @"
+            string sql = @"
 WITH ""inputvalues"" AS (
 	SELECT @key ""key"", @field ""field"", @value ""value""
 ), ""updatedrows"" AS ( 
@@ -321,61 +318,63 @@ WHERE NOT EXISTS (
 	AND ""updatedrows"".""field"" = ""insertvalues"".""field""
 );
 ";
-			var execute = true;
-			var executionTimer = Stopwatch.StartNew();
-			while (execute)
-			{
-				try
-				{
-					using (var transaction = _connection.BeginTransaction(IsolationLevel.Serializable))
-					{
-						foreach (var keyValuePair in keyValuePairs)
-						{
-							_connection.Execute(sql, new {key = key, field = keyValuePair.Key, value = keyValuePair.Value}, transaction);
-						}
-						transaction.Commit();
-						execute = false;
-					}
-				}
-				catch (PostgresException exception)
-				{
-					if (!exception.SqlState.Equals("40001"))
-						throw;
-				}
 
-				if(executionTimer.Elapsed > _options.TransactionSynchronisationTimeout)
-					throw new TimeoutException("SetRangeInHash experienced timeout while trying to execute transaction");
-			}
-		}
+            var execute = true;
+            var executionTimer = Stopwatch.StartNew();
+            while (execute)
+            {
+                try
+                {
+                    _storage.UseTransaction(_dedicatedConnection, (connection, transaction) =>
+                    {
+                        foreach (var keyValuePair in keyValuePairs)
+                        {
+                            connection.Execute(sql, new { key = key, field = keyValuePair.Key, value = keyValuePair.Value }, transaction);
+                        }
 
-		public override Dictionary<string, string> GetAllEntriesFromHash(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+                        transaction.Commit();
+                        execute = false;
+                    });
+                }
+                catch (PostgresException exception)
+                {
+                    if (!exception.SqlState.Equals("40001"))
+                        throw;
+                }
 
-			var result = _connection.Query<SqlHash>(
-				$@"SELECT ""field"" ""Field"", ""value"" ""Value"" 
-					FROM ""{_options.SchemaName}"".""hash"" 
-					WHERE ""key"" = @key;
-					",
-				new { key })
-				.ToDictionary(x => x.Field, x => x.Value);
+                if (executionTimer.Elapsed > _options.TransactionSynchronisationTimeout)
+                    throw new TimeoutException("SetRangeInHash experienced timeout while trying to execute transaction");
+            }
+        }
 
-			return result.Count != 0 ? result : null;
-		}
+        public override Dictionary<string, string> GetAllEntriesFromHash(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-		public override void AnnounceServer(string serverId, ServerContext context)
-		{
-			if (serverId == null) throw new ArgumentNullException(nameof(serverId));
-			if (context == null) throw new ArgumentNullException(nameof(context));
+            var result = _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<SqlHash>($@"
+SELECT ""field"" ""Field"", ""value"" ""Value"" 
+FROM ""{_options.SchemaName}"".""hash"" 
+WHERE ""key"" = @key;",
+                    new { key })
+                .ToDictionary(x => x.Field, x => x.Value));
 
-			var data = new ServerData
-			{
-				WorkerCount = context.WorkerCount,
-				Queues = context.Queues,
-				StartedAt = DateTime.UtcNow,
-			};
+            return result.Count != 0 ? result : null;
+        }
 
-			string sql = @"
+        public override void AnnounceServer(string serverId, ServerContext context)
+        {
+            if (serverId == null) throw new ArgumentNullException(nameof(serverId));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            var data = new ServerData
+            {
+                WorkerCount = context.WorkerCount,
+                Queues = context.Queues,
+                StartedAt = DateTime.UtcNow,
+            };
+
+            string sql = @"
 WITH ""inputvalues"" AS (
 	SELECT @id ""id"", @data ""data"", NOW() AT TIME ZONE 'UTC' ""lastheartbeat""
 ), ""updatedrows"" AS ( 
@@ -394,166 +393,274 @@ WHERE NOT EXISTS (
 );
 ";
 
-			_connection.Execute(sql,
-				new { id = serverId, data = SerializationHelper.Serialize(data) });
-		}
+            _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Execute(sql, new { id = serverId, data = SerializationHelper.Serialize(data) }));
+        }
 
-		public override void RemoveServer(string serverId)
-		{
-			if (serverId == null) throw new ArgumentNullException(nameof(serverId));
+        public override void RemoveServer(string serverId)
+        {
+            if (serverId == null) throw new ArgumentNullException(nameof(serverId));
 
-			_connection.Execute(
-				$@"DELETE FROM ""{_options.SchemaName}"".""server"" WHERE ""id"" = @id;",
-				new { id = serverId });
-		}
+            _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Execute($@"DELETE FROM ""{_options.SchemaName}"".""server"" WHERE ""id"" = @id;", new { id = serverId }));
+        }
 
-		public override void Heartbeat(string serverId)
-		{
-			if (serverId == null) throw new ArgumentNullException(nameof(serverId));
+        public override void Heartbeat(string serverId)
+        {
+            if (serverId == null) throw new ArgumentNullException(nameof(serverId));
 
-			string query =
-				$@"UPDATE ""{_options.SchemaName}"".""server"" 
+            string query =
+                $@"UPDATE ""{_options.SchemaName}"".""server"" 
 				SET ""lastheartbeat"" = NOW() AT TIME ZONE 'UTC' 
 				WHERE ""id"" = @id;";
 
-			int affectedRows = _connection.Execute(query, new { id = serverId });
+            int affectedRows = _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Execute(query, new { id = serverId }));
 
-			if (affectedRows == 0)
-			{
-				throw new BackgroundServerGoneException();
-			}
-		}
+            if (affectedRows == 0)
+            {
+                throw new BackgroundServerGoneException();
+            }
+        }
 
-		public override int RemoveTimedOutServers(TimeSpan timeOut)
-		{
-			if (timeOut.Duration() != timeOut)
-			{
-				throw new ArgumentException("The `timeOut` value must be positive.", nameof(timeOut));
-			}
+        public override int RemoveTimedOutServers(TimeSpan timeOut)
+        {
+            if (timeOut.Duration() != timeOut)
+            {
+                throw new ArgumentException("The `timeOut` value must be positive.", nameof(timeOut));
+            }
 
-			string query =
-				$@"DELETE FROM ""{_options.SchemaName}"".""server"" 
-				WHERE ""lastheartbeat"" < (NOW() AT TIME ZONE 'UTC' - INTERVAL '{(
-					long) timeOut.TotalMilliseconds} MILLISECONDS');";
+            string query =
+                $@"DELETE FROM ""{_options.SchemaName}"".""server"" 
+				WHERE ""lastheartbeat"" < (NOW() AT TIME ZONE 'UTC' - INTERVAL '{(long)timeOut.TotalMilliseconds} MILLISECONDS');";
 
-			return _connection.Execute(query);
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection.Execute(query));
+        }
 
-		public override long GetSetCount(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override long GetSetCount(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select count(""key"") from ""{_options.SchemaName}"".""set"" where ""key"" = @key";
+            string query = $@"select count(""key"") from ""{_options.SchemaName}"".""set"" where ""key"" = @key";
 
-			return _connection.Query<long>(query, new {key}).First();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<long>(query, new { key })
+                .First());
+        }
 
-		public override List<string> GetAllItemsFromList(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override List<string> GetAllItemsFromList(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select ""value"" from ""{_options.SchemaName}"".""list"" where ""key"" = @key order by ""id"" desc";
+            string query = $@"select ""value"" from ""{_options.SchemaName}"".""list"" where ""key"" = @key order by ""id"" desc";
 
-			return _connection.Query<string>(query, new { key }).ToList();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(query, new { key })
+                .ToList());
+        }
 
-		public override long GetCounter(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override long GetCounter(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select sum(s.""Value"") from (select sum(""value"") as ""Value"" from ""{_options.SchemaName}"".""counter"" where ""key"" = @key) s";
+            string query = $@"select sum(s.""Value"") from (select sum(""value"") as ""Value"" from ""{_options.SchemaName}"".""counter"" where ""key"" = @key) s";
 
-			return _connection.Query<long?>(query, new {key}).SingleOrDefault() ?? 0;
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<long?>(query, new { key }).SingleOrDefault() ?? 0);
+        }
 
-		public override long GetListCount(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override long GetListCount(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select count(""id"") from ""{_options.SchemaName}"".""list"" where ""key"" = @key";
+            string query = $@"select count(""id"") from ""{_options.SchemaName}"".""list"" where ""key"" = @key";
 
-			return _connection.Query<long>(query, new { key }).SingleOrDefault();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<long>(query, new { key })
+                .SingleOrDefault());
+        }
 
-		public override TimeSpan GetListTtl(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override TimeSpan GetListTtl(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""list"" where ""key"" = @key";
+            string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""list"" where ""key"" = @key";
 
-			var result = _connection.Query<DateTime?>(query, new { key }).Single();
-			if (!result.HasValue) return TimeSpan.FromSeconds(-1);
+            var result = _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<DateTime?>(query, new { key })
+                .Single());
+            if (!result.HasValue) return TimeSpan.FromSeconds(-1);
 
-			return result.Value - DateTime.UtcNow;
-		}
+            return result.Value - DateTime.UtcNow;
+        }
 
-		public override List<string> GetRangeFromList(string key, int startingFrom, int endingAt)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override List<string> GetRangeFromList(string key, int startingFrom, int endingAt)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select ""value"" from (
+            string query = $@"select ""value"" from (
 					select ""value"", row_number() over (order by ""id"" desc) as row_num 
 					from ""{_options.SchemaName}"".""list""
 					where ""key"" = @key 
 				) as s where s.row_num between @startingFrom and @endingAt";
 
-			return _connection.Query<string>(query, new {key, startingFrom = startingFrom + 1, endingAt = endingAt + 1}).ToList();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(query, new { key, startingFrom = startingFrom + 1, endingAt = endingAt + 1 })
+                .ToList());
+        }
 
-		public override long GetHashCount(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override long GetHashCount(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select count(""id"") from ""{_options.SchemaName}"".""hash"" where ""key"" = @key";
+            string query = $@"select count(""id"") from ""{_options.SchemaName}"".""hash"" where ""key"" = @key";
 
-			return _connection.Query<long>(query, new { key }).SingleOrDefault();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<long>(query, new { key })
+                .SingleOrDefault());
+        }
 
-		public override TimeSpan GetHashTtl(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override TimeSpan GetHashTtl(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""hash"" where ""key"" = @key";
+            string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""hash"" where ""key"" = @key";
 
-			var result = _connection.Query<DateTime?>(query, new { key }).Single();
-			if (!result.HasValue) return TimeSpan.FromSeconds(-1);
+            var result = _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<DateTime?>(query, new { key })
+                .Single());
+            if (!result.HasValue) return TimeSpan.FromSeconds(-1);
 
-			return result.Value - DateTime.UtcNow;
-		}
+            return result.Value - DateTime.UtcNow;
+        }
 
-		public override List<string> GetRangeFromSet(string key, int startingFrom, int endingAt)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override List<string> GetRangeFromSet(string key, int startingFrom, int endingAt)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select ""value"" from (
+            string query = $@"select ""value"" from (
 					select ""value"", row_number() over (order by ""id"" ASC) as row_num 
 					from ""{_options.SchemaName}"".""set""
 					where ""key"" = @key 
 				) as s where s.row_num between @startingFrom and @endingAt";
 
-			return _connection.Query<string>(query, new { key, startingFrom = startingFrom + 1, endingAt = endingAt + 1 }).ToList();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(query, new { key, startingFrom = startingFrom + 1, endingAt = endingAt + 1 })
+                .ToList());
+        }
 
-		public override TimeSpan GetSetTtl(string key)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
+        public override TimeSpan GetSetTtl(string key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
 
-			string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""set"" where ""key"" = @key";
+            string query = $@"select min(""expireat"") from ""{_options.SchemaName}"".""set"" where ""key"" = @key";
 
-			var result = _connection.Query<DateTime?>(query, new { key }).SingleOrDefault();
-			if (!result.HasValue) return TimeSpan.FromSeconds(-1);
+            var result = _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<DateTime?>(query, new { key })
+                .SingleOrDefault());
+            if (!result.HasValue) return TimeSpan.FromSeconds(-1);
 
-			return result.Value - DateTime.UtcNow;
-		}
+            return result.Value - DateTime.UtcNow;
+        }
 
-		public override string GetValueFromHash(string key, string name)
-		{
-			if (key == null) throw new ArgumentNullException(nameof(key));
-			if (name == null) throw new ArgumentNullException(nameof(name));
+        public override string GetValueFromHash(string key, string name)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
-			string query = $@"select ""value"" from ""{_options.SchemaName}"".""hash"" where ""key"" = @key and ""field"" = @field";
+            string query = $@"select ""value"" from ""{_options.SchemaName}"".""hash"" where ""key"" = @key and ""field"" = @field";
 
-			return _connection.Query<string>(query, new { key, field = name }).SingleOrDefault();
-		}
+            return _storage.UseConnection(_dedicatedConnection, connection => connection
+                .Query<string>(query, new { key, field = name })
+                .SingleOrDefault());
+        }
+
+        private DbConnection _dedicatedConnection;
+
+        private IDisposable AcquireLock(string resource, TimeSpan timeout)
+        {
+            if (_dedicatedConnection == null)
+            {
+                _dedicatedConnection = _storage.CreateAndOpenConnection();
+            }
+
+            var lockId = Guid.NewGuid();
+
+            if (!_lockedResources.ContainsKey(resource))
+            {
+                try
+                {
+                    PostgreSqlDistributedLock.Acquire(_dedicatedConnection, resource, timeout, _options);
+                }
+                catch (Exception)
+                {
+                    ReleaseLock(resource, lockId, true);
+                    throw;
+                }
+
+                _lockedResources.Add(resource, new HashSet<Guid>());
+            }
+
+            _lockedResources[resource].Add(lockId);
+            return new DisposableLock(this, resource, lockId);
+        }
+
+        private void ReleaseLock(string resource, Guid lockId, bool onDisposing)
+        {
+            try
+            {
+                if (!_lockedResources.TryGetValue(resource, out var resourceLocks))
+                {
+                    return;
+                }
+
+                if (!resourceLocks.Contains(lockId))
+                {
+                    return;
+                }
+
+                if (resourceLocks.Remove(lockId)
+                    && resourceLocks.Count == 0
+                    && _lockedResources.Remove(resource)
+                    && _dedicatedConnection.State == ConnectionState.Open)
+                {
+                    PostgreSqlDistributedLock.Release(_dedicatedConnection, resource, _options);
+                }
+            }
+            catch (Exception)
+            {
+                if (!onDisposing)
+                {
+                    throw;
+                }
+            }
+            finally
+            {
+                if (_lockedResources.Count == 0)
+                {
+                    _storage.ReleaseConnection(_dedicatedConnection);
+                    _dedicatedConnection = null;
+                }
+            }
+        }
+
+        private class DisposableLock : IDisposable
+        {
+            private readonly PostgreSqlConnection _connection;
+            private readonly string _resource;
+            private readonly Guid _lockId;
+
+            public DisposableLock(PostgreSqlConnection connection, string resource, Guid lockId)
+            {
+                _connection = connection;
+                _resource = resource;
+                _lockId = lockId;
+            }
+
+            public void Dispose()
+            {
+                _connection.ReleaseLock(_resource, _lockId, true);
+            }
+        }
     }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -332,7 +332,7 @@ WHERE NOT EXISTS (
                             connection.Execute(sql, new { key = key, field = keyValuePair.Key, value = keyValuePair.Value }, transaction);
                         }
 
-                        transaction.Commit();
+                        transaction?.Commit();
                         execute = false;
                     });
                 }

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
@@ -37,6 +37,21 @@ namespace Hangfire.PostgreSql
 
         internal static void Acquire(IDbConnection connection, string resource, TimeSpan timeout, PostgreSqlStorageOptions options)
         {
+            if (connection == null)
+            {
+                throw new ArgumentNullException(nameof(connection));
+            }
+
+            if (string.IsNullOrEmpty(resource))
+            {
+                throw new ArgumentNullException(nameof(resource));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             if (connection.State != ConnectionState.Open)
             {
                 // When we are passing a closed connection to Dapper's Execute method,
@@ -59,6 +74,21 @@ namespace Hangfire.PostgreSql
 
         internal static void Release(IDbConnection connection, string resource, PostgreSqlStorageOptions options)
         {
+            if (connection == null)
+            {
+                throw new ArgumentNullException(nameof(connection));
+            }
+
+            if (resource == null)
+            {
+                throw new ArgumentNullException(nameof(resource));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
             var rowsAffected = connection.Execute(
                 $@"DELETE FROM ""{options.SchemaName}"".""lock"" WHERE ""resource"" = @resource;",
                 new { resource });

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
@@ -19,61 +19,79 @@
 //   
 //    Special thanks goes to him.
 
+using Dapper;
+using Hangfire.Logging;
 using System;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
-using Dapper;
-using Hangfire.Logging;
 
 namespace Hangfire.PostgreSql
 {
-    public sealed class PostgreSqlDistributedLock : IDisposable
+    public sealed class PostgreSqlDistributedLock
     {
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
 
-        private readonly string _resource;
-        private readonly IDbConnection _connection;
-        private readonly PostgreSqlStorageOptions _options;
-        private bool _completed;
+        private static void Log(string resource, string message, Exception ex) =>
+            Logger.WarnException($"{resource}: {message}", ex);
 
-        public PostgreSqlDistributedLock(string resource, TimeSpan timeout, IDbConnection connection,
-            PostgreSqlStorageOptions options)
+        internal static void Acquire(IDbConnection connection, string resource, TimeSpan timeout, PostgreSqlStorageOptions options)
         {
-            if (string.IsNullOrEmpty(resource)) throw new ArgumentNullException(nameof(resource));
+            if (connection.State != ConnectionState.Open)
+            {
+                // When we are passing a closed connection to Dapper's Execute method,
+                // it kindly opens it for us, but after command execution, it will be closed
+                // automatically, and our just-acquired application lock will immediately
+                // be released. This is not behavior we want to achieve, so let's throw an
+                // exception instead.
+                throw new InvalidOperationException("Connection must be open before acquiring a distributed lock.");
+            }
 
-            _resource = resource;
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
-
-            if (_options.UseNativeDatabaseTransactions)
-                PostgreSqlDistributedLock_Init_Transaction(resource, timeout, connection, options);
+            if (options.UseNativeDatabaseTransactions)
+            {
+                TransactionLockHandler.Lock(resource, timeout, connection, options);
+            }
             else
-                PostgreSqlDistributedLock_Init_UpdateCount(resource, timeout, connection, options);
+            {
+                UpdateCountLockHandler.Lock(resource, timeout, connection, options);
+            }
         }
 
-        private static void PostgreSqlDistributedLock_Init_Transaction(string resource, TimeSpan timeout,
-            IDbConnection connection, PostgreSqlStorageOptions options)
+        internal static void Release(IDbConnection connection, string resource, PostgreSqlStorageOptions options)
         {
-            var lockAcquiringTime = Stopwatch.StartNew();
+            var rowsAffected = connection.Execute(
+                $@"DELETE FROM ""{options.SchemaName}"".""lock"" WHERE ""resource"" = @resource;",
+                new { resource });
 
-            bool tryAcquireLock = true;
-
-            while (tryAcquireLock)
+            if (rowsAffected <= 0)
             {
-                if (connection.State != ConnectionState.Open)
-                {
-                    connection.Open();
-                }
+                throw new PostgreSqlDistributedLockException($"Could not release a lock on the resource '{resource}'. Lock does not exists.");
+            }
+        }
 
-                TryRemoveDeadlock(resource, connection, options);
+        private static class TransactionLockHandler
+        {
+            public static void Lock(string resource, TimeSpan timeout, IDbConnection connection, PostgreSqlStorageOptions options)
+            {
+                var lockAcquiringTime = Stopwatch.StartNew();
 
-                try
+                bool tryAcquireLock = true;
+
+                while (tryAcquireLock)
                 {
-                    int rowsAffected;
-                    using (var trx = connection.BeginTransaction(IsolationLevel.RepeatableRead))
+                    if (connection.State != ConnectionState.Open)
                     {
-                        rowsAffected = connection.Execute($@"
+                        connection.Open();
+                    }
+
+                    TryRemoveLock(resource, connection, options);
+
+                    try
+                    {
+                        int rowsAffected;
+                        using (var trx = connection.BeginTransaction(IsolationLevel.RepeatableRead))
+                        {
+                            rowsAffected = connection.Execute($@"
 INSERT INTO ""{options.SchemaName}"".""lock""(""resource"", ""acquired"") 
 SELECT @resource, @acquired
 WHERE NOT EXISTS (
@@ -81,83 +99,81 @@ WHERE NOT EXISTS (
     WHERE ""resource"" = @resource
 );
 ",
-                            new
-                            {
-                                resource = resource,
-                                acquired = DateTime.UtcNow
-                            }, trx);
-                        trx.Commit();
+                                new
+                                {
+                                    resource = resource,
+                                    acquired = DateTime.UtcNow
+                                }, trx);
+                            trx.Commit();
+                        }
+                        if (rowsAffected > 0) return;
                     }
-                    if (rowsAffected > 0) return;
-                }
-                catch (Exception ex)
-                {
-                    Log(resource, "Failed to lock with transaction", ex);
-                }
-
-                if (lockAcquiringTime.ElapsedMilliseconds > timeout.TotalMilliseconds)
-                {
-                    tryAcquireLock = false;
-                }
-                else
-                {
-                    int sleepDuration = (int)(timeout.TotalMilliseconds - lockAcquiringTime.ElapsedMilliseconds);
-                    if (sleepDuration > 1000) sleepDuration = 1000;
-                    if (sleepDuration > 0)
+                    catch (Exception ex)
                     {
-                        Thread.Sleep(sleepDuration);
+                        Log(resource, "Failed to lock with transaction", ex);
                     }
-                    else
+
+                    if (lockAcquiringTime.ElapsedMilliseconds > timeout.TotalMilliseconds)
                     {
                         tryAcquireLock = false;
                     }
-                }
-            }
-
-            throw new PostgreSqlDistributedLockException(
-                $"Could not place a lock on the resource \'{resource}\': Lock timeout.");
-        }
-
-        private static void TryRemoveDeadlock(string resource, IDbConnection connection, PostgreSqlStorageOptions options)
-        {
-            try
-            {
-                using (var transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead))
-                {
-                    int affected = -1;
-
-                    affected = connection.Execute($@"DELETE FROM ""{options.SchemaName}"".""lock"" WHERE ""resource"" = @resource AND ""acquired"" < @timeout",
-                        new
+                    else
+                    {
+                        int sleepDuration = (int)(timeout.TotalMilliseconds - lockAcquiringTime.ElapsedMilliseconds);
+                        if (sleepDuration > 1000) sleepDuration = 1000;
+                        if (sleepDuration > 0)
                         {
-                            resource = resource,
-                            timeout = DateTime.UtcNow - options.DistributedLockTimeout
-                        });
-
-                    transaction.Commit();
-                }
-            }
-            catch (Exception ex)
-            {
-                Log(resource, "Failed to remove lock", ex);
-            }
-        }
-
-        private static void PostgreSqlDistributedLock_Init_UpdateCount(string resource, TimeSpan timeout, IDbConnection connection, PostgreSqlStorageOptions options)
-        {
-            var lockAcquiringTime = Stopwatch.StartNew();
-
-            bool tryAcquireLock = true;
-
-            while (tryAcquireLock)
-            {
-                if (connection.State != ConnectionState.Open)
-                {
-                    connection.Open();
+                            Thread.Sleep(sleepDuration);
+                        }
+                        else
+                        {
+                            tryAcquireLock = false;
+                        }
+                    }
                 }
 
+                throw new PostgreSqlDistributedLockException(
+                    $"Could not place a lock on the resource \'{resource}\': Lock timeout.");
+            }
+
+            private static void TryRemoveLock(string resource, IDbConnection connection, PostgreSqlStorageOptions options)
+            {
                 try
                 {
-                    connection.Execute($@"
+                    using (var transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead))
+                    {
+                        int affected = -1;
+
+                        affected = connection.Execute($@"DELETE FROM ""{options.SchemaName}"".""lock"" WHERE ""resource"" = @resource AND ""acquired"" < @timeout",
+                            new
+                            {
+                                resource = resource,
+                                timeout = DateTime.UtcNow - options.DistributedLockTimeout
+                            });
+
+                        transaction.Commit();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log(resource, "Failed to remove lock", ex);
+                }
+            }
+        }
+
+        private static class UpdateCountLockHandler
+        {
+            public static void Lock(string resource, TimeSpan timeout, IDbConnection connection, PostgreSqlStorageOptions options)
+            {
+                var lockAcquiringTime = Stopwatch.StartNew();
+
+                bool tryAcquireLock = true;
+
+                while (tryAcquireLock)
+                {
+                    try
+                    {
+                        connection.Execute($@"
 INSERT INTO ""{options.SchemaName}"".""lock""(""resource"", ""updatecount"", ""acquired"") 
 SELECT @resource, 0, @acquired
 WHERE NOT EXISTS (
@@ -165,62 +181,37 @@ WHERE NOT EXISTS (
     WHERE ""resource"" = @resource
 );
 ", new
+                        {
+                            resource = resource,
+                            acquired = DateTime.UtcNow
+                        });
+                    }
+                    catch (Exception ex)
                     {
-                        resource = resource,
-                        acquired = DateTime.UtcNow
-                    });
-                }
-                catch (Exception ex)
-                {
-                    Log(resource, "Failed to lock with update count", ex);
-                }
+                        Log(resource, "Failed to lock with update count", ex);
+                    }
 
-                int rowsAffected = connection.Execute(
-                    $@"UPDATE ""{options.SchemaName}"".""lock"" SET ""updatecount"" = 1 WHERE ""updatecount"" = 0 AND ""resource"" = @resource",
-                    new { resource });
+                    int rowsAffected = connection.Execute(
+                        $@"UPDATE ""{options.SchemaName}"".""lock"" SET ""updatecount"" = 1 WHERE ""updatecount"" = 0 AND ""resource"" = @resource",
+                        new { resource });
 
-                if (rowsAffected > 0) return;
+                    if (rowsAffected > 0) return;
 
-                if (lockAcquiringTime.ElapsedMilliseconds > timeout.TotalMilliseconds)
-                    tryAcquireLock = false;
-                else
-                {
-                    int sleepDuration = (int)(timeout.TotalMilliseconds - lockAcquiringTime.ElapsedMilliseconds);
-                    if (sleepDuration > 1000) sleepDuration = 1000;
-                    if (sleepDuration > 0)
-                        Thread.Sleep(sleepDuration);
-                    else
+                    if (lockAcquiringTime.ElapsedMilliseconds > timeout.TotalMilliseconds)
                         tryAcquireLock = false;
+                    else
+                    {
+                        int sleepDuration = (int)(timeout.TotalMilliseconds - lockAcquiringTime.ElapsedMilliseconds);
+                        if (sleepDuration > 1000) sleepDuration = 1000;
+                        if (sleepDuration > 0)
+                            Thread.Sleep(sleepDuration);
+                        else
+                            tryAcquireLock = false;
+                    }
                 }
-            }
 
-            throw new PostgreSqlDistributedLockException(
-                $"Could not place a lock on the resource '{resource}': Lock timeout.");
-        }
-
-        private static void Log(string resource, string message, Exception ex) =>
-            Logger.WarnException($"{resource}: {message}", ex);
-
-        public void Dispose()
-        {
-            if (_completed) return;
-
-            _completed = true;
-
-            int rowsAffected = _connection.Execute($@"
-DELETE FROM ""{_options.SchemaName}"".""lock"" 
-WHERE ""resource"" = @resource;
-",
-            new
-            {
-                resource = _resource
-            });
-
-
-            if (rowsAffected <= 0)
-            {
                 throw new PostgreSqlDistributedLockException(
-                    $"Could not release a lock on the resource '{_resource}'. Lock does not exists.");
+                    $"Could not place a lock on the resource '{resource}': Lock timeout.");
             }
         }
     }

--- a/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
@@ -19,30 +19,26 @@
 //   
 //    Special thanks goes to him.
 
-using System;
-using System.Data;
 using Dapper;
 using Hangfire.Storage;
+using System;
 
 namespace Hangfire.PostgreSql
 {
     public class PostgreSqlFetchedJob : IFetchedJob
     {
         private readonly PostgreSqlStorage _storage;
-        private readonly PostgreSqlStorageOptions _options;
         private bool _disposed;
         private bool _removedFromQueue;
         private bool _requeued;
 
         public PostgreSqlFetchedJob(
-            PostgreSqlStorage storage, 
-            PostgreSqlStorageOptions options,
-            long id, 
-            string jobId, 
+            PostgreSqlStorage storage,
+            long id,
+            string jobId,
             string queue)
         {
-	        _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
 
             Id = id;
             JobId = jobId ?? throw new ArgumentNullException(nameof(jobId));
@@ -55,9 +51,9 @@ namespace Hangfire.PostgreSql
 
         public void RemoveFromQueue()
         {
-            _storage.UseConnection(connection => connection.Execute(
+            _storage.UseConnection(null, connection => connection.Execute(
                 @"
-DELETE FROM """ + _options.SchemaName + @""".""jobqueue"" 
+DELETE FROM """ + _storage.Options.SchemaName + @""".""jobqueue"" 
 WHERE ""id"" = @id;
 ",
                 new { id = Id }));
@@ -67,9 +63,9 @@ WHERE ""id"" = @id;
 
         public void Requeue()
         {
-            _storage.UseConnection(connection => connection.Execute(
+            _storage.UseConnection(null, connection => connection.Execute(
                 @"
-UPDATE """ + _options.SchemaName + @""".""jobqueue"" 
+UPDATE """ + _storage.Options.SchemaName + @""".""jobqueue"" 
 SET ""fetchedat"" = NULL 
 WHERE ""id"" = @id;
 ",

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -19,56 +19,54 @@
 //   
 //    Special thanks goes to him.
 
+using Dapper;
+using Hangfire.PostgreSql.Properties;
+using Hangfire.Storage;
+using Npgsql;
 using System;
 using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
-using Dapper;
-using Hangfire.PostgreSql.Properties;
-using Hangfire.Storage;
-using Npgsql;
 
 namespace Hangfire.PostgreSql
 {
-	public class PostgreSqlJobQueue : IPersistentJobQueue
-	{
+    public class PostgreSqlJobQueue : IPersistentJobQueue
+    {
         internal static readonly AutoResetEvent NewItemInQueueEvent = new AutoResetEvent(true);
-		private readonly PostgreSqlStorageOptions _options;
-		private readonly PostgreSqlStorage _storage;
+        private readonly PostgreSqlStorage _storage;
 
-		public PostgreSqlJobQueue(PostgreSqlStorage storage, PostgreSqlStorageOptions options)
-		{
-			_options = options ?? throw new ArgumentNullException(nameof(options));
-			_storage = storage ?? throw new ArgumentNullException(nameof(storage));
-		}
+        public PostgreSqlJobQueue(PostgreSqlStorage storage, PostgreSqlStorageOptions options)
+        {
+            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        }
 
 
-		[NotNull]
-		public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
-		{
-			if (_options.UseNativeDatabaseTransactions)
-				return Dequeue_Transaction(queues, cancellationToken);
-			
-			return Dequeue_UpdateCount(queues, cancellationToken);
-		}
+        [NotNull]
+        public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
+        {
+            if (_storage.Options.UseNativeDatabaseTransactions)
+                return Dequeue_Transaction(queues, cancellationToken);
+
+            return Dequeue_UpdateCount(queues, cancellationToken);
+        }
 
 
-		[NotNull]
-		internal IFetchedJob Dequeue_Transaction(string[] queues, CancellationToken cancellationToken)
-		{
-			if (queues == null) throw new ArgumentNullException(nameof(queues));
-			if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
+        [NotNull]
+        internal IFetchedJob Dequeue_Transaction(string[] queues, CancellationToken cancellationToken)
+        {
+            if (queues == null) throw new ArgumentNullException(nameof(queues));
+            if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
 
-			long timeoutSeconds = (long) _options.InvisibilityTimeout.Negate().TotalSeconds;
-			FetchedJob fetchedJob;
+            long timeoutSeconds = (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
+            FetchedJob fetchedJob;
 
-			string fetchJobSqlTemplate = @"
-UPDATE """ + _options.SchemaName + @""".""jobqueue"" 
+            string fetchJobSqlTemplate = @"
+UPDATE """ + _storage.Options.SchemaName + @""".""jobqueue"" 
 SET ""fetchedat"" = NOW() AT TIME ZONE 'UTC'
 WHERE ""id"" = (
     SELECT ""id"" 
-    FROM """ + _options.SchemaName + $@""".""jobqueue"" 
+    FROM """ + _storage.Options.SchemaName + $@""".""jobqueue"" 
     WHERE ""queue"" = ANY (@queues)
     AND ""fetchedat"" {{0}}
     ORDER BY ""queue"", ""fetchedat"", ""jobid""
@@ -78,102 +76,102 @@ WHERE ""id"" = (
 RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fetchedat"" AS ""FetchedAt"";
 ";
 
-			var fetchConditions = new[]
-			{"IS NULL", $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'"};
-			var currentQueryIndex = 0;
+            var fetchConditions = new[]
+            {"IS NULL", $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'"};
+            var currentQueryIndex = 0;
 
-			do
-			{
-				cancellationToken.ThrowIfCancellationRequested();
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
 
-				string fetchJobSql = string.Format(fetchJobSqlTemplate, fetchConditions[currentQueryIndex]);
+                string fetchJobSql = string.Format(fetchJobSqlTemplate, fetchConditions[currentQueryIndex]);
 
-				Utils.Utils.TryExecute(() =>
-				{
-					var connection = _storage.CreateAndOpenConnection();
+                Utils.Utils.TryExecute(() =>
+                {
+                    var connection = _storage.CreateAndOpenConnection();
 
-					try
-					{
-						using (var trx = connection.BeginTransaction(IsolationLevel.ReadCommitted))
-						{
-							var jobToFetch = connection.Query<FetchedJob>(
-									fetchJobSql,
-									new {queues = queues.ToList()}, trx)
-								.SingleOrDefault();
+                    try
+                    {
+                        using (var trx = connection.BeginTransaction(IsolationLevel.ReadCommitted))
+                        {
+                            var jobToFetch = connection.Query<FetchedJob>(
+                                    fetchJobSql,
+                                    new { queues = queues.ToList() }, trx)
+                                .SingleOrDefault();
 
-							trx.Commit();
+                            trx.Commit();
 
-							return jobToFetch;
-						}
-					}
-					catch (InvalidOperationException)
-					{
-						// thrown by .SingleOrDefault(): stop the exception propagation if the fetched job was concurrently fetched by another worker
-					}
-					finally
-					{
-						_storage.ReleaseConnection(connection);
-					}
-				},
-					out fetchedJob,
-					ex =>
-					{
-						NpgsqlException npgSqlException = ex as NpgsqlException;
-						PostgresException postgresException = ex as PostgresException;
+                            return jobToFetch;
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // thrown by .SingleOrDefault(): stop the exception propagation if the fetched job was concurrently fetched by another worker
+                        return null;
+                    }
+                    finally
+                    {
+                        _storage.ReleaseConnection(connection);
+                    }
+                },
+                    out fetchedJob,
+                    ex =>
+                    {
+                        NpgsqlException npgSqlException = ex as NpgsqlException;
+                        PostgresException postgresException = ex as PostgresException;
                         bool smoothException = false;
 
                         if (postgresException != null)
-						{
-							if (postgresException.SqlState.Equals("40001"))
-								smoothException = true;
-						}
+                        {
+                            if (postgresException.SqlState.Equals("40001"))
+                                smoothException = true;
+                        }
 
-						return smoothException;
-					});
+                        return smoothException;
+                    });
 
-				if (fetchedJob == null)
-				{
-					if (currentQueryIndex == fetchConditions.Length - 1)
-					{
-                        WaitHandle.WaitAny(new []{cancellationToken.WaitHandle, NewItemInQueueEvent},_options.QueuePollInterval);
-						cancellationToken.ThrowIfCancellationRequested();
-					}
-				}
+                if (fetchedJob == null)
+                {
+                    if (currentQueryIndex == fetchConditions.Length - 1)
+                    {
+                        WaitHandle.WaitAny(new[] { cancellationToken.WaitHandle, NewItemInQueueEvent }, _storage.Options.QueuePollInterval);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                }
 
-				currentQueryIndex = (currentQueryIndex + 1)%fetchConditions.Length;
-			} while (fetchedJob == null);
+                currentQueryIndex = (currentQueryIndex + 1) % fetchConditions.Length;
+            } while (fetchedJob == null);
 
-			return new PostgreSqlFetchedJob(
-				_storage,
-				_options,
-				fetchedJob.Id,
-				fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
-				fetchedJob.Queue);
-		}
-
-
-		[NotNull]
-		internal IFetchedJob Dequeue_UpdateCount(string[] queues, CancellationToken cancellationToken)
-		{
-			if (queues == null) throw new ArgumentNullException("queues");
-			if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", "queues");
+            return new PostgreSqlFetchedJob(
+                _storage,
+                fetchedJob.Id,
+                fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
+                fetchedJob.Queue);
+        }
 
 
-			long timeoutSeconds = (long) _options.InvisibilityTimeout.Negate().TotalSeconds;
-			FetchedJob markJobAsFetched = null;
+        [NotNull]
+        internal IFetchedJob Dequeue_UpdateCount(string[] queues, CancellationToken cancellationToken)
+        {
+            if (queues == null) throw new ArgumentNullException("queues");
+            if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", "queues");
 
 
-			string jobToFetchSqlTemplate = @"
+            long timeoutSeconds = (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
+            FetchedJob markJobAsFetched = null;
+
+
+            string jobToFetchSqlTemplate = @"
 SELECT ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fetchedat"" AS ""FetchedAt"", ""updatecount"" AS ""UpdateCount""
-FROM """ + _options.SchemaName + $@""".""jobqueue"" 
+FROM """ + _storage.Options.SchemaName + $@""".""jobqueue"" 
 WHERE ""queue"" = ANY (@queues)
 AND ""fetchedat"" {{0}} 
 ORDER BY ""queue"", ""fetchedat"", ""jobid"" 
 LIMIT 1;
 ";
 
-			string markJobAsFetchedSql = @"
-UPDATE """ + _options.SchemaName + @""".""jobqueue"" 
+            string markJobAsFetchedSql = @"
+UPDATE """ + _storage.Options.SchemaName + @""".""jobqueue"" 
 SET ""fetchedat"" = NOW() AT TIME ZONE 'UTC', 
     ""updatecount"" = (""updatecount"" + 1) % 2000000000
 WHERE ""id"" = @Id 
@@ -181,67 +179,66 @@ AND ""updatecount"" = @UpdateCount
 RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fetchedat"" AS ""FetchedAt"";
 ";
 
-			var fetchConditions = new[]
-			{"IS NULL", $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'"};
-			var currentQueryIndex = 0;
+            var fetchConditions = new[]
+            {"IS NULL", $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'"};
+            var currentQueryIndex = 0;
 
-			do
-			{
-				cancellationToken.ThrowIfCancellationRequested();
+            do
+            {
+                cancellationToken.ThrowIfCancellationRequested();
 
-				string jobToFetchJobSql = string.Format(jobToFetchSqlTemplate, fetchConditions[currentQueryIndex]);
+                string jobToFetchJobSql = string.Format(jobToFetchSqlTemplate, fetchConditions[currentQueryIndex]);
 
-				FetchedJob jobToFetch = _storage.UseConnection(connection => connection.Query<FetchedJob>(
-					jobToFetchJobSql,
-					new {queues = queues.ToList()})
-					.SingleOrDefault());
+                FetchedJob jobToFetch = _storage.UseConnection(null, connection => connection.Query<FetchedJob>(
+                    jobToFetchJobSql,
+                    new { queues = queues.ToList() })
+                    .SingleOrDefault());
 
-				if (jobToFetch == null)
-				{
-					if (currentQueryIndex == fetchConditions.Length - 1)
-					{
-						cancellationToken.WaitHandle.WaitOne(_options.QueuePollInterval);
-						cancellationToken.ThrowIfCancellationRequested();
-					}
-				}
-				else
-				{
-					markJobAsFetched = _storage.UseConnection(connection => connection.Query<FetchedJob>(
-						markJobAsFetchedSql,
-						jobToFetch)
-						.SingleOrDefault());
-				}
+                if (jobToFetch == null)
+                {
+                    if (currentQueryIndex == fetchConditions.Length - 1)
+                    {
+                        cancellationToken.WaitHandle.WaitOne(_storage.Options.QueuePollInterval);
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                }
+                else
+                {
+                    markJobAsFetched = _storage.UseConnection(null, connection => connection.Query<FetchedJob>(
+                        markJobAsFetchedSql,
+                        jobToFetch)
+                        .SingleOrDefault());
+                }
 
 
-				currentQueryIndex = (currentQueryIndex + 1)%fetchConditions.Length;
-			} while (markJobAsFetched == null);
+                currentQueryIndex = (currentQueryIndex + 1) % fetchConditions.Length;
+            } while (markJobAsFetched == null);
 
-			return new PostgreSqlFetchedJob(
-				_storage,
-				_options,
-				markJobAsFetched.Id,
-				markJobAsFetched.JobId.ToString(CultureInfo.InvariantCulture),
-				markJobAsFetched.Queue);
-		}
+            return new PostgreSqlFetchedJob(
+                _storage,
+                markJobAsFetched.Id,
+                markJobAsFetched.JobId.ToString(CultureInfo.InvariantCulture),
+                markJobAsFetched.Queue);
+        }
 
-		public void Enqueue(IDbConnection connection, string queue, string jobId)
-		{
-			string enqueueJobSql = @"
-INSERT INTO """ + _options.SchemaName + @""".""jobqueue"" (""jobid"", ""queue"") 
+        public void Enqueue(IDbConnection connection, string queue, string jobId)
+        {
+            string enqueueJobSql = @"
+INSERT INTO """ + _storage.Options.SchemaName + @""".""jobqueue"" (""jobid"", ""queue"") 
 VALUES (@jobId, @queue);
 ";
 
-			connection.Execute(enqueueJobSql, new {jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue});
-		}
+            connection.Execute(enqueueJobSql, new { jobId = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue });
+        }
 
-		[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-		private class FetchedJob
-		{
-			public long Id { get; set; }
-			public long JobId { get; set; }
-			public string Queue { get; set; }
-			public DateTime? FetchedAt { get; set; }
-			public int UpdateCount { get; set; }
-		}
-	}
+        [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+        private class FetchedJob
+        {
+            public long Id { get; set; }
+            public long JobId { get; set; }
+            public string Queue { get; set; }
+            public DateTime? FetchedAt { get; set; }
+            public int UpdateCount { get; set; }
+        }
+    }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueueProvider.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueueProvider.cs
@@ -44,7 +44,7 @@ namespace Hangfire.PostgreSql
 
         public IPersistentJobQueueMonitoringApi GetJobQueueMonitoringApi()
         {
-            return new PostgreSqlJobQueueMonitoringApi(Storage, Options);
+            return new PostgreSqlJobQueueMonitoringApi(Storage);
         }
     }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -133,7 +133,7 @@ namespace Hangfire.PostgreSql
             InitializeQueueProviders();
         }
 
-        public PersistentJobQueueProviderCollection QueueProviders { get; private set; }
+        public PersistentJobQueueProviderCollection QueueProviders { get; internal set; }
 
         public override IMonitoringApi GetMonitoringApi()
         {

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -35,7 +35,7 @@ namespace Hangfire.PostgreSql
             QueuePollInterval = TimeSpan.FromSeconds(15);
             InvisibilityTimeout = TimeSpan.FromMinutes(30);
             DistributedLockTimeout = TimeSpan.FromMinutes(10);
-	        TransactionSynchronisationTimeout = TimeSpan.FromMilliseconds(500);
+            TransactionSynchronisationTimeout = TimeSpan.FromMilliseconds(500);
             SchemaName = "hangfire";
             UseNativeDatabaseTransactions = true;
             PrepareSchemaIfNecessary = true;
@@ -44,7 +44,7 @@ namespace Hangfire.PostgreSql
         public TimeSpan QueuePollInterval
         {
             get => _queuePollInterval;
-	        set
+            set
             {
                 ThrowIfValueIsNotPositive(value, nameof(QueuePollInterval));
                 _queuePollInterval = value;
@@ -54,7 +54,7 @@ namespace Hangfire.PostgreSql
         public TimeSpan InvisibilityTimeout
         {
             get => _invisibilityTimeout;
-	        set
+            set
             {
                 ThrowIfValueIsNotPositive(value, nameof(InvisibilityTimeout));
                 _invisibilityTimeout = value;
@@ -64,22 +64,22 @@ namespace Hangfire.PostgreSql
         public TimeSpan DistributedLockTimeout
         {
             get => _distributedLockTimeout;
-	        set
+            set
             {
                 ThrowIfValueIsNotPositive(value, nameof(DistributedLockTimeout));
                 _distributedLockTimeout = value;
             }
         }
 
-	    public TimeSpan TransactionSynchronisationTimeout
-	    {
-			get => _transactionSerializationTimeout;
-		    set
-		    {
-			    ThrowIfValueIsNotPositive(value, nameof(TransactionSynchronisationTimeout));
-			    _transactionSerializationTimeout = value;
-		    }
-		}
+        public TimeSpan TransactionSynchronisationTimeout
+        {
+            get => _transactionSerializationTimeout;
+            set
+            {
+                ThrowIfValueIsNotPositive(value, nameof(TransactionSynchronisationTimeout));
+                _transactionSerializationTimeout = value;
+            }
+        }
 
         public bool UseNativeDatabaseTransactions { get; set; }
         public bool PrepareSchemaIfNecessary { get; set; }

--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -83,14 +83,6 @@ namespace Hangfire.PostgreSql
             return new TransactionScope(scopeOption, transactionOptions);
         }
 
-        private static void Current_TransactionCompleted(object sender, TransactionEventArgs e)
-        {
-            if (e.Transaction.TransactionInformation.Status == TransactionStatus.Committed)
-            {
-                PostgreSqlJobQueue.NewItemInQueueEvent.Set();
-            }
-        }
-
         public override void ExpireJob(string jobId, TimeSpan expireIn)
         {
             var sql = $@"

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
@@ -1,297 +1,271 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Globalization;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Transactions;
-using Dapper;
+﻿using Dapper;
 using Hangfire.Common;
 using Hangfire.Server;
 using Hangfire.Storage;
 using Moq;
 using Npgsql;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlConnectionFacts
-	{
-		private readonly Mock<IPersistentJobQueue> _queue;
-		private readonly Mock<IPersistentJobQueueProvider> _provider;
-		private readonly PersistentJobQueueProviderCollection _providers;
-		private readonly PostgreSqlStorageOptions _options;
+    public class PostgreSqlConnectionFacts : IClassFixture<PostgreSqlStorageFixture>
+    {
+        private readonly Mock<IPersistentJobQueue> _queue;
+        private readonly Mock<IPersistentJobQueueProvider> _provider;
+        private readonly PersistentJobQueueProviderCollection _providers;
+        private readonly PostgreSqlStorageOptions _options;
+        private readonly PostgreSqlStorageFixture _fixture;
+        private readonly ITestOutputHelper _outputHelper;
 
-		public PostgreSqlConnectionFacts()
-		{
-			_queue = new Mock<IPersistentJobQueue>();
+        private PostgreSqlStorage Storage => _fixture.Storage;
 
-			_provider = new Mock<IPersistentJobQueueProvider>();
-			_provider.Setup(x => x.GetJobQueue())
-				.Returns(_queue.Object);
+        public PostgreSqlConnectionFacts(PostgreSqlStorageFixture fixture, ITestOutputHelper outputHelper)
+        {
+            _queue = new Mock<IPersistentJobQueue>();
 
-			_providers = new PersistentJobQueueProviderCollection(_provider.Object);
+            _provider = new Mock<IPersistentJobQueueProvider>();
+            _provider.Setup(x => x.GetJobQueue())
+                .Returns(_queue.Object);
 
-			_options = new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName()
-			};
-		}
+            _providers = new PersistentJobQueueProviderCollection(_provider.Object);
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenConnectionIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlConnection(null, _providers, _options));
+            _options = new PostgreSqlStorageOptions()
+            {
+                SchemaName = GetSchemaName(),
+                EnableTransactionScopeEnlistment = true
+            };
+            _fixture = fixture;
+            _outputHelper = outputHelper;
+        }
 
-			Assert.Equal("connection", exception.ParamName);
-		}
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenStorageIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlConnection(null));
 
-		[Fact, CleanDatabase]
-		public void Ctor_ThrowsAnException_WhenProvidersCollectionIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlConnection(ConnectionUtils.CreateConnection(), null, _options));
+            Assert.Equal("storage", exception.ParamName);
+        }
 
-			Assert.Equal("queueProviders", exception.ParamName);
-		}
+        [Fact, CleanDatabase]
+        public void Ctor_ThrowsAnException_WhenOptionsIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlConnection(new PostgreSqlStorage("some-connection-string", null, null)));
 
-		[Fact, CleanDatabase]
-		public void Ctor_ThrowsAnException_WhenOptionsIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlConnection(ConnectionUtils.CreateConnection(), _providers, null));
-
-			Assert.Equal("options", exception.ParamName);
-		}
-
-		[Fact, CleanDatabase]
-		public void Dispose_DisposesTheConnection_IfOwned()
-		{
-			using (var sqlConnection = ConnectionUtils.CreateConnection())
-			{
-				var connection = new PostgreSqlConnection(sqlConnection, _providers, _options);
-
-				connection.Dispose();
-
-				Assert.Equal(ConnectionState.Closed, sqlConnection.State);
-			}
-		}
-
-		[Fact, CleanDatabase]
-		public void Dispose_DoesNotDisposeTheConnection_IfNotOwned()
-		{
-			using (var sqlConnection = ConnectionUtils.CreateConnection())
-			{
-				var connection = new PostgreSqlConnection(sqlConnection, _providers, ownsConnection: false, options: _options);
-
-				connection.Dispose();
-
-				Assert.Equal(ConnectionState.Open, sqlConnection.State);
-			}
-		}
+            Assert.Equal("options", exception.ParamName);
+        }
 
 
-		[Fact, CleanDatabase]
-		public void FetchNextJob_DelegatesItsExecution_ToTheQueue()
-		{
-			UseConnection(connection =>
-			{
-				var token = new CancellationToken();
-				var queues = new[] {"default"};
+        [Fact, CleanDatabase]
+        public void FetchNextJob_DelegatesItsExecution_ToTheQueue()
+        {
+            UseConnection(connection =>
+            {
+                var token = new CancellationToken();
+                var queues = new[] { "default" };
 
-				connection.FetchNextJob(queues, token);
+                connection.FetchNextJob(queues, token);
 
-				_queue.Verify(x => x.Dequeue(queues, token));
-			});
-		}
+                _queue.Verify(x => x.Dequeue(queues, token));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void FetchNextJob_Throws_IfMultipleProvidersResolved()
-		{
-			UseConnection(connection =>
-			{
-				var token = new CancellationToken();
-				var anotherProvider = new Mock<IPersistentJobQueueProvider>();
-				_providers.Add(anotherProvider.Object, new[] {"critical"});
+        [Fact, CleanDatabase]
+        public void FetchNextJob_Throws_IfMultipleProvidersResolved()
+        {
+            UseConnection(connection =>
+            {
+                var token = new CancellationToken();
+                var anotherProvider = new Mock<IPersistentJobQueueProvider>();
+                _providers.Add(anotherProvider.Object, new[] { "critical" });
 
-				Assert.Throws<InvalidOperationException>(
-					() => connection.FetchNextJob(new[] {"critical", "default"}, token));
-			});
-		}
+                Assert.Throws<InvalidOperationException>(
+                    () => connection.FetchNextJob(new[] { "critical", "default" }, token));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void CreateWriteTransaction_ReturnsNonNullInstance()
-		{
-			UseConnection(connection =>
-			{
-				var transaction = connection.CreateWriteTransaction();
-				Assert.NotNull(transaction);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void CreateWriteTransaction_ReturnsNonNullInstance()
+        {
+            UseConnection(connection =>
+            {
+                var transaction = connection.CreateWriteTransaction();
+                Assert.NotNull(transaction);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void AcquireLock_ReturnsNonNullInstance()
-		{
-			UseConnection(connection =>
-			{
-				var @lock = connection.AcquireDistributedLock("1", TimeSpan.FromSeconds(1));
-				Assert.NotNull(@lock);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void AcquireLock_ReturnsNonNullInstance()
+        {
+            UseConnection(connection =>
+            {
+                var @lock = connection.AcquireDistributedLock("1", TimeSpan.FromSeconds(1));
+                Assert.NotNull(@lock);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void CreateExpiredJob_ThrowsAnException_WhenJobIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.CreateExpiredJob(
-						null,
-						new Dictionary<string, string>(),
-						DateTime.UtcNow,
-						TimeSpan.Zero));
+        [Fact, CleanDatabase]
+        public void CreateExpiredJob_ThrowsAnException_WhenJobIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.CreateExpiredJob(
+                        null,
+                        new Dictionary<string, string>(),
+                        DateTime.UtcNow,
+                        TimeSpan.Zero));
 
-				Assert.Equal("job", exception.ParamName);
-			});
-		}
+                Assert.Equal("job", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void CreateExpiredJob_ThrowsAnException_WhenParametersCollectionIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.CreateExpiredJob(
-						Job.FromExpression(() => SampleMethod("hello")),
-						null,
-						DateTime.UtcNow,
-						TimeSpan.Zero));
+        [Fact, CleanDatabase]
+        public void CreateExpiredJob_ThrowsAnException_WhenParametersCollectionIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.CreateExpiredJob(
+                        Job.FromExpression(() => SampleMethod("hello")),
+                        null,
+                        DateTime.UtcNow,
+                        TimeSpan.Zero));
 
-				Assert.Equal("parameters", exception.ParamName);
-			});
-		}
+                Assert.Equal("parameters", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void CreateExpiredJob_CreatesAJobInTheStorage_AndSetsItsParameters()
-		{
-			UseConnections((sql, connection) =>
-			{
-				var createdAt = new DateTime(2012, 12, 12);
-				var jobId = connection.CreateExpiredJob(
-					Job.FromExpression(() => SampleMethod("Hello")),
-					new Dictionary<string, string> {{"Key1", "Value1"}, {"Key2", "Value2"}},
-					createdAt,
-					TimeSpan.FromDays(1));
+        [Fact, CleanDatabase]
+        public void CreateExpiredJob_CreatesAJobInTheStorage_AndSetsItsParameters()
+        {
+            UseConnections((sql, connection) =>
+            {
+                var createdAt = new DateTime(2012, 12, 12);
+                var jobId = connection.CreateExpiredJob(
+                    Job.FromExpression(() => SampleMethod("Hello")),
+                    new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
+                    createdAt,
+                    TimeSpan.FromDays(1));
 
-				Assert.NotNull(jobId);
-				Assert.NotEmpty(jobId);
+                Assert.NotNull(jobId);
+                Assert.NotEmpty(jobId);
 
-				var sqlJob = sql.Query(@"select * from """ + GetSchemaName() + @""".""job""").Single();
-				Assert.Equal(jobId, sqlJob.id.ToString());
-				Assert.Equal(createdAt, sqlJob.createdat);
-				Assert.Null((long?) sqlJob.stateid);
-				Assert.Null((string) sqlJob.statename);
+                var sqlJob = sql.Query(@"select * from """ + GetSchemaName() + @""".""job""").Single();
+                Assert.Equal(jobId, sqlJob.id.ToString());
+                Assert.Equal(createdAt, sqlJob.createdat);
+                Assert.Null((long?)sqlJob.stateid);
+                Assert.Null((string)sqlJob.statename);
 
-				var invocationData = SerializationHelper.Deserialize<InvocationData>((string) sqlJob.invocationdata);
-				invocationData.Arguments = sqlJob.arguments;
+                var invocationData = SerializationHelper.Deserialize<InvocationData>((string)sqlJob.invocationdata);
+                invocationData.Arguments = sqlJob.arguments;
 
-				var job = invocationData.DeserializeJob();
-				Assert.Equal(typeof (PostgreSqlConnectionFacts), job.Type);
-				Assert.Equal("SampleMethod", job.Method.Name);
-				Assert.Equal("Hello", job.Args[0]);
+                var job = invocationData.DeserializeJob();
+                Assert.Equal(typeof(PostgreSqlConnectionFacts), job.Type);
+                Assert.Equal("SampleMethod", job.Method.Name);
+                Assert.Equal("Hello", job.Args[0]);
 
-				Assert.True(createdAt.AddDays(1).AddMinutes(-1) < sqlJob.expireat);
-				Assert.True(sqlJob.expireat < createdAt.AddDays(1).AddMinutes(1));
+                Assert.True(createdAt.AddDays(1).AddMinutes(-1) < sqlJob.expireat);
+                Assert.True(sqlJob.expireat < createdAt.AddDays(1).AddMinutes(1));
 
-				var parameters = sql.Query(
-					@"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id",
-					new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture)})
-					.ToDictionary(x => (string) x.name, x => (string) x.value);
+                var parameters = sql.Query(
+                    @"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id",
+                    new { id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture) })
+                    .ToDictionary(x => (string)x.name, x => (string)x.value);
 
-				Assert.Equal("Value1", parameters["Key1"]);
-				Assert.Equal("Value2", parameters["Key2"]);
-			});
-		}
+                Assert.Equal("Value1", parameters["Key1"]);
+                Assert.Equal("Value2", parameters["Key2"]);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetJobData_ThrowsAnException_WhenJobIdIsNull()
-		{
-			UseConnection(connection => Assert.Throws<ArgumentNullException>(
-				() => connection.GetJobData(null)));
-		}
+        [Fact, CleanDatabase]
+        public void GetJobData_ThrowsAnException_WhenJobIdIsNull()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentNullException>(
+                () => connection.GetJobData(null)));
+        }
 
-		[Fact, CleanDatabase]
-		public void GetJobData_ReturnsNull_WhenThereIsNoSuchJob()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetJobData("1");
-				Assert.Null(result);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void GetJobData_ReturnsNull_WhenThereIsNoSuchJob()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetJobData("1");
+                Assert.Null(result);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetJobData_ReturnsResult_WhenJobExists()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetJobData_ReturnsResult_WhenJobExists()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
 values (@invocationData, @arguments, @stateName, now() at time zone 'utc') returning ""id""";
 
-			UseConnections((sql, connection) =>
-			{
-				var job = Job.FromExpression(() => SampleMethod("wrong"));
+            UseConnections((sql, connection) =>
+            {
+                var job = Job.FromExpression(() => SampleMethod("wrong"));
 
-                var jobId = (long) sql.Query(
-					arrangeSql,
-					new
-					{
-						invocationData = SerializationHelper.Serialize(InvocationData.SerializeJob(job)),
-						stateName = "Succeeded",
-						arguments = "[\"\\\"Arguments\\\"\"]"
+                var jobId = (long)sql.Query(
+                    arrangeSql,
+                    new
+                    {
+                        invocationData = SerializationHelper.Serialize(InvocationData.SerializeJob(job)),
+                        stateName = "Succeeded",
+                        arguments = "[\"\\\"Arguments\\\"\"]"
                     }).Single().id;
 
-				var result = connection.GetJobData(jobId.ToString());
+                var result = connection.GetJobData(jobId.ToString());
                 var now = DateTime.UtcNow.AddMinutes(-1);
 
                 Assert.NotNull(result);
-				Assert.NotNull(result.Job);
-				Assert.Equal("Succeeded", result.State);
-				Assert.Equal("Arguments", result.Job.Args[0]);
-				Assert.Null(result.LoadException);
-				Assert.True(DateTime.UtcNow.AddMinutes(-1) < result.CreatedAt);
-				Assert.True(result.CreatedAt < DateTime.UtcNow.AddMinutes(1));
-			});
-		}
+                Assert.NotNull(result.Job);
+                Assert.Equal("Succeeded", result.State);
+                Assert.Equal("Arguments", result.Job.Args[0]);
+                Assert.Null(result.LoadException);
+                Assert.True(DateTime.UtcNow.AddMinutes(-1) < result.CreatedAt);
+                Assert.True(result.CreatedAt < DateTime.UtcNow.AddMinutes(1));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetStateData_ThrowsAnException_WhenJobIdIsNull()
-		{
-			UseConnection(
-				connection => Assert.Throws<ArgumentNullException>(
-					() => connection.GetStateData(null)));
-		}
-        
-		[Fact, CleanDatabase]
-		public void GetStateData_ReturnsNull_IfThereIsNoSuchState()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetStateData("1");
-				Assert.Null(result);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void GetStateData_ThrowsAnException_WhenJobIdIsNull()
+        {
+            UseConnection(
+                connection => Assert.Throws<ArgumentNullException>(
+                    () => connection.GetStateData(null)));
+        }
 
-		[Fact, CleanDatabase]
-		public void GetStateData_ReturnsCorrectData()
-		{
-			string createJobSql = @"
+        [Fact, CleanDatabase]
+        public void GetStateData_ReturnsNull_IfThereIsNoSuchState()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetStateData("1");
+                Assert.Null(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetStateData_ReturnsCorrectData()
+        {
+            string createJobSql = @"
 INSERT INTO """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
     VALUES ('', '', '', now() at time zone 'utc') RETURNING ""id"";
             ";
 
-			string createStateSql = @"
+            string createStateSql = @"
 insert into """ + GetSchemaName() + @""".""state"" (""jobid"", ""name"", ""createdat"")
 VALUES(@jobId, 'old-state', now() at time zone 'utc');
 
@@ -299,189 +273,189 @@ insert into """ + GetSchemaName() + @""".""state"" (""jobid"", ""name"", ""reaso
 VALUES(@jobId, @name, @reason, @data, now() at time zone 'utc')
 returning ""id"";";
 
-			string updateJobStateSql = @"
+            string updateJobStateSql = @"
     update """ + GetSchemaName() + @""".""job""
     set ""stateid"" = @stateId
     where ""id"" = @jobId;
 ";
 
-			UseConnections((sql, connection) =>
-			{
-				var data = new Dictionary<string, string>
-				{
-					{"Key", "Value"}
-				};
+            UseConnections((sql, connection) =>
+            {
+                var data = new Dictionary<string, string>
+                {
+                    {"Key", "Value"}
+                };
 
-				var jobId = (long) sql.Query(createJobSql).Single().id;
+                var jobId = (long)sql.Query(createJobSql).Single().id;
 
-				var stateId = (long) sql.Query(
-					createStateSql,
-					new {jobId = jobId, name = "Name", reason = "Reason", @data = SerializationHelper.Serialize(data)}).Single().id;
+                var stateId = (long)sql.Query(
+                    createStateSql,
+                    new { jobId = jobId, name = "Name", reason = "Reason", @data = SerializationHelper.Serialize(data) }).Single().id;
 
-				sql.Execute(updateJobStateSql, new {jobId = jobId, stateId = stateId});
+                sql.Execute(updateJobStateSql, new { jobId = jobId, stateId = stateId });
 
-				var result = connection.GetStateData(jobId.ToString(CultureInfo.InvariantCulture));
-				Assert.NotNull(result);
+                var result = connection.GetStateData(jobId.ToString(CultureInfo.InvariantCulture));
+                Assert.NotNull(result);
 
-				Assert.Equal("Name", result.Name);
-				Assert.Equal("Reason", result.Reason);
-				Assert.Equal("Value", result.Data["Key"]);
-			});
-		}
+                Assert.Equal("Name", result.Name);
+                Assert.Equal("Reason", result.Reason);
+                Assert.Equal("Value", result.Data["Key"]);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetJobData_ReturnsJobLoadException_IfThereWasADeserializationException()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetJobData_ReturnsJobLoadException_IfThereWasADeserializationException()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
 values (@invocationData, @arguments, @stateName, now() at time zone 'utc') returning ""id""";
 
-			UseConnections((sql, connection) =>
-			{
-				var jobId = sql.Query(
-					arrangeSql,
-					new
-					{
-						invocationData = SerializationHelper.Serialize(new InvocationData(null, null, null, null)),
-						stateName = "Succeeded",
-						arguments = "['Arguments']"
-					}).Single();
+            UseConnections((sql, connection) =>
+            {
+                var jobId = sql.Query(
+                    arrangeSql,
+                    new
+                    {
+                        invocationData = SerializationHelper.Serialize(new InvocationData(null, null, null, null)),
+                        stateName = "Succeeded",
+                        arguments = "['Arguments']"
+                    }).Single();
 
-				var result = connection.GetJobData(((long) jobId.id).ToString());
+                var result = connection.GetJobData(((long)jobId.id).ToString());
 
-				Assert.NotNull(result.LoadException);
-			});
-		}
+                Assert.NotNull(result.LoadException);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetParameter_ThrowsAnException_WhenJobIdIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.SetJobParameter(null, "name", "value"));
+        [Fact, CleanDatabase]
+        public void SetParameter_ThrowsAnException_WhenJobIdIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.SetJobParameter(null, "name", "value"));
 
-				Assert.Equal("id", exception.ParamName);
-			});
-		}
+                Assert.Equal("id", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetParameter_ThrowsAnException_WhenNameIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.SetJobParameter("1", null, "value"));
+        [Fact, CleanDatabase]
+        public void SetParameter_ThrowsAnException_WhenNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.SetJobParameter("1", null, "value"));
 
-				Assert.Equal("name", exception.ParamName);
-			});
-		}
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetParameters_CreatesNewParameter_WhenParameterWithTheGivenNameDoesNotExists()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void SetParameters_CreatesNewParameter_WhenParameterWithTheGivenNameDoesNotExists()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values ('', '', now() at time zone 'utc') returning ""id""";
 
-			UseConnections((sql, connection) =>
-			{
-				var job = sql.Query(arrangeSql).Single();
-				string jobId = job.id.ToString();
+            UseConnections((sql, connection) =>
+            {
+                var job = sql.Query(arrangeSql).Single();
+                string jobId = job.id.ToString();
 
-				connection.SetJobParameter(jobId, "Name", "Value");
+                connection.SetJobParameter(jobId, "Name", "Value");
 
-				var parameter = sql.Query(
-					@"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
-					new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name"}).Single();
+                var parameter = sql.Query(
+                    @"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
+                    new { id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name" }).Single();
 
-				Assert.Equal("Value", parameter.value);
-			});
-		}
+                Assert.Equal("Value", parameter.value);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetParameter_UpdatesValue_WhenParameterWithTheGivenName_AlreadyExists()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void SetParameter_UpdatesValue_WhenParameterWithTheGivenName_AlreadyExists()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values ('', '', now() at time zone 'utc') returning ""id""";
 
-			UseConnections((sql, connection) =>
-			{
-				var job = sql.Query(arrangeSql).Single();
-				string jobId = job.id.ToString();
+            UseConnections((sql, connection) =>
+            {
+                var job = sql.Query(arrangeSql).Single();
+                string jobId = job.id.ToString();
 
-				connection.SetJobParameter(jobId, "Name", "Value");
-				connection.SetJobParameter(jobId, "Name", "AnotherValue");
+                connection.SetJobParameter(jobId, "Name", "Value");
+                connection.SetJobParameter(jobId, "Name", "AnotherValue");
 
-				var parameter = sql.Query(
-					@"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
-					new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name"}).Single();
+                var parameter = sql.Query(
+                    @"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
+                    new { id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name" }).Single();
 
-				Assert.Equal("AnotherValue", parameter.value);
-			});
-		}
+                Assert.Equal("AnotherValue", parameter.value);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetParameter_CanAcceptNulls_AsValues()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void SetParameter_CanAcceptNulls_AsValues()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values ('', '', now() at time zone 'utc') returning ""id""";
 
-			UseConnections((sql, connection) =>
-			{
-				var job = sql.Query(arrangeSql).Single();
-				string jobId = job.id.ToString();
+            UseConnections((sql, connection) =>
+            {
+                var job = sql.Query(arrangeSql).Single();
+                string jobId = job.id.ToString();
 
-				connection.SetJobParameter(jobId, "Name", null);
+                connection.SetJobParameter(jobId, "Name", null);
 
-				var parameter = sql.Query(
-					@"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
-					new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name"}).Single();
+                var parameter = sql.Query(
+                    @"select * from """ + GetSchemaName() + @""".""jobparameter"" where ""jobid"" = @id and ""name"" = @name",
+                    new { id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), name = "Name" }).Single();
 
-				Assert.Equal((string) null, parameter.value);
-			});
-		}
+                Assert.Equal((string)null, parameter.value);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetParameter_ThrowsAnException_WhenJobIdIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetJobParameter(null, "hello"));
+        [Fact, CleanDatabase]
+        public void GetParameter_ThrowsAnException_WhenJobIdIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetJobParameter(null, "hello"));
 
-				Assert.Equal("id", exception.ParamName);
-			});
-		}
+                Assert.Equal("id", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetParameter_ThrowsAnException_WhenNameIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetJobParameter("1", null));
+        [Fact, CleanDatabase]
+        public void GetParameter_ThrowsAnException_WhenNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetJobParameter("1", null));
 
-				Assert.Equal("name", exception.ParamName);
-			});
-		}
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetParameter_ReturnsNull_WhenParameterDoesNotExists()
-		{
-			UseConnection(connection =>
-			{
-				var value = connection.GetJobParameter("1", "hello");
-				Assert.Null(value);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void GetParameter_ReturnsNull_WhenParameterDoesNotExists()
+        {
+            UseConnection(connection =>
+            {
+                var value = connection.GetJobParameter("1", "hello");
+                Assert.Null(value);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetParameter_ReturnsParameterValue_WhenJobExists()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetParameter_ReturnsParameterValue_WhenJobExists()
+        {
+            string arrangeSql = @"
 WITH ""insertedjob"" AS (
     INSERT INTO """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
     VALUES ('', '', now() at time zone 'utc') RETURNING ""id""
@@ -491,53 +465,53 @@ SELECT ""insertedjob"".""id"", @name, @value
 FROM ""insertedjob""
 RETURNING ""jobid"";
 ";
-			UseConnections((sql, connection) =>
-			{
-				var id = sql.Query<long>(
-					arrangeSql,
-					new {name = "name", value = "value"}).Single();
+            UseConnections((sql, connection) =>
+            {
+                var id = sql.Query<long>(
+                    arrangeSql,
+                    new { name = "name", value = "value" }).Single();
 
-				var value = connection.GetJobParameter(Convert.ToString(id, CultureInfo.InvariantCulture), "name");
+                var value = connection.GetJobParameter(Convert.ToString(id, CultureInfo.InvariantCulture), "name");
 
-				Assert.Equal("value", value);
-			});
-		}
+                Assert.Equal("value", value);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetFirstByLowestScoreFromSet_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetFirstByLowestScoreFromSet(null, 0, 1));
+        [Fact, CleanDatabase]
+        public void GetFirstByLowestScoreFromSet_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetFirstByLowestScoreFromSet(null, 0, 1));
 
-				Assert.Equal("key", exception.ParamName);
-			});
-		}
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetFirstByLowestScoreFromSet_ThrowsAnException_ToScoreIsLowerThanFromScore()
-		{
-			UseConnection(connection => Assert.Throws<ArgumentException>(
-				() => connection.GetFirstByLowestScoreFromSet("key", 0, -1)));
-		}
+        [Fact, CleanDatabase]
+        public void GetFirstByLowestScoreFromSet_ThrowsAnException_ToScoreIsLowerThanFromScore()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentException>(
+                () => connection.GetFirstByLowestScoreFromSet("key", 0, -1)));
+        }
 
-		[Fact, CleanDatabase]
-		public void GetFirstByLowestScoreFromSet_ReturnsNull_WhenTheKeyDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetFirstByLowestScoreFromSet(
-					"key", 0, 1);
+        [Fact, CleanDatabase]
+        public void GetFirstByLowestScoreFromSet_ReturnsNull_WhenTheKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetFirstByLowestScoreFromSet(
+                    "key", 0, 1);
 
-				Assert.Null(result);
-			});
-		}
+                Assert.Null(result);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetFirstByLowestScoreFromSet_ReturnsTheValueWithTheLowestScore()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetFirstByLowestScoreFromSet_ReturnsTheValueWithTheLowestScore()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""set"" (""key"", ""score"", ""value"")
 values 
 ('key', 1.0, '1.0'),
@@ -545,793 +519,820 @@ values
 ('key', -5.0, '-5.0'),
 ('another-key', -2.0, '-2.0')";
 
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(arrangeSql);
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql);
 
-				var result = connection.GetFirstByLowestScoreFromSet("key", -1.0, 3.0);
+                var result = connection.GetFirstByLowestScoreFromSet("key", -1.0, 3.0);
 
-				Assert.Equal("-1.0", result);
-			});
-		}
+                Assert.Equal("-1.0", result);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void AnnounceServer_ThrowsAnException_WhenServerIdIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.AnnounceServer(null, new ServerContext()));
+        [Fact, CleanDatabase]
+        public void AnnounceServer_ThrowsAnException_WhenServerIdIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.AnnounceServer(null, new ServerContext()));
 
-				Assert.Equal("serverId", exception.ParamName);
-			});
-		}
+                Assert.Equal("serverId", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void AnnounceServer_ThrowsAnException_WhenContextIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.AnnounceServer("server", null));
+        [Fact, CleanDatabase]
+        public void AnnounceServer_ThrowsAnException_WhenContextIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.AnnounceServer("server", null));
 
-				Assert.Equal("context", exception.ParamName);
-			});
-		}
+                Assert.Equal("context", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void AnnounceServer_CreatesOrUpdatesARecord()
-		{
-			UseConnections((sql, connection) =>
-			{
-				var context1 = new ServerContext
-				{
-					Queues = new[] {"critical", "default"},
-					WorkerCount = 4
-				};
-				connection.AnnounceServer("server", context1);
+        [Fact, CleanDatabase]
+        public void AnnounceServer_CreatesOrUpdatesARecord()
+        {
+            UseConnections((sql, connection) =>
+            {
+                var context1 = new ServerContext
+                {
+                    Queues = new[] { "critical", "default" },
+                    WorkerCount = 4
+                };
+                connection.AnnounceServer("server", context1);
 
-				var server = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
-				Assert.Equal("server", server.id);
-				Assert.True(((string) server.data).StartsWith(
-					"{\"WorkerCount\":4,\"Queues\":[\"critical\",\"default\"],\"StartedAt\":"),
-					server.data);
-				Assert.NotNull(server.lastheartbeat);
+                var server = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
+                Assert.Equal("server", server.id);
+                Assert.True(((string)server.data).StartsWith(
+                    "{\"WorkerCount\":4,\"Queues\":[\"critical\",\"default\"],\"StartedAt\":"),
+                    server.data);
+                Assert.NotNull(server.lastheartbeat);
 
-				var context2 = new ServerContext
-				{
-					Queues = new[] {"default"},
-					WorkerCount = 1000
-				};
-				connection.AnnounceServer("server", context2);
-				var sameServer = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
-				Assert.Equal("server", sameServer.id);
-				Assert.Contains("1000", sameServer.data);
-			});
-		}
+                var context2 = new ServerContext
+                {
+                    Queues = new[] { "default" },
+                    WorkerCount = 1000
+                };
+                connection.AnnounceServer("server", context2);
+                var sameServer = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
+                Assert.Equal("server", sameServer.id);
+                Assert.Contains("1000", sameServer.data);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void RemoveServer_ThrowsAnException_WhenServerIdIsNull()
-		{
-			UseConnection(connection => Assert.Throws<ArgumentNullException>(
-				() => connection.RemoveServer(null)));
-		}
+        [Fact, CleanDatabase]
+        public void RemoveServer_ThrowsAnException_WhenServerIdIsNull()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentNullException>(
+                () => connection.RemoveServer(null)));
+        }
 
-		[Fact, CleanDatabase]
-		public void RemoveServer_RemovesAServerRecord()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void RemoveServer_RemovesAServerRecord()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""server"" (""id"", ""data"", ""lastheartbeat"")
 values ('Server1', '', now() at time zone 'utc'),
 ('Server2', '', now() at time zone 'utc')";
 
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(arrangeSql);
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql);
 
-				connection.RemoveServer("Server1");
+                connection.RemoveServer("Server1");
 
-				var server = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
-				Assert.NotEqual("Server1", server.Id, StringComparer.OrdinalIgnoreCase);
-			});
-		}
+                var server = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
+                Assert.NotEqual("Server1", server.Id, StringComparer.OrdinalIgnoreCase);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Heartbeat_ThrowsAnException_WhenServerIdIsNull()
-		{
-			UseConnection(connection => Assert.Throws<ArgumentNullException>(
-				() => connection.Heartbeat(null)));
-		}
+        [Fact, CleanDatabase]
+        public void Heartbeat_ThrowsAnException_WhenServerIdIsNull()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentNullException>(
+                () => connection.Heartbeat(null)));
+        }
 
-		[Fact, CleanDatabase]
-		public void Heartbeat_ThrowsBackgroundServerGoneException_WhenServerDisappeared()
-		{
-			string disappearedServerId = Guid.NewGuid().ToString();
+        [Fact, CleanDatabase]
+        public void Heartbeat_ThrowsBackgroundServerGoneException_WhenServerDisappeared()
+        {
+            string disappearedServerId = Guid.NewGuid().ToString();
 
-			UseConnection(connection => Assert.Throws<BackgroundServerGoneException>(
-				() => connection.Heartbeat(disappearedServerId)));
-		}
+            UseConnection(connection => Assert.Throws<BackgroundServerGoneException>(
+                () => connection.Heartbeat(disappearedServerId)));
+        }
 
-		[Fact, CleanDatabase]
-		public void Heartbeat_UpdatesLastHeartbeat_OfTheServerWithGivenId()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void Heartbeat_UpdatesLastHeartbeat_OfTheServerWithGivenId()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""server"" (""id"", ""data"", ""lastheartbeat"")
 values
 ('server1', '', '2012-12-12 12:12:12'),
 ('server2', '', '2012-12-12 12:12:12')";
 
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(arrangeSql);
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql);
 
-				connection.Heartbeat("server1");
+                connection.Heartbeat("server1");
 
-				var servers = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""")
-					.ToDictionary(x => (string) x.id, x => (DateTime) x.lastheartbeat);
+                var servers = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""")
+                    .ToDictionary(x => (string)x.id, x => (DateTime)x.lastheartbeat);
 
-				Assert.NotEqual(2012, servers["server1"].Year);
-				Assert.Equal(2012, servers["server2"].Year);
-			});
-		}
+                Assert.NotEqual(2012, servers["server1"].Year);
+                Assert.Equal(2012, servers["server2"].Year);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void RemoveTimedOutServers_ThrowsAnException_WhenTimeOutIsNegative()
-		{
-			UseConnection(connection => Assert.Throws<ArgumentException>(
-				() => connection.RemoveTimedOutServers(TimeSpan.FromMinutes(-5))));
-		}
+        [Fact, CleanDatabase]
+        public void RemoveTimedOutServers_ThrowsAnException_WhenTimeOutIsNegative()
+        {
+            UseConnection(connection => Assert.Throws<ArgumentException>(
+                () => connection.RemoveTimedOutServers(TimeSpan.FromMinutes(-5))));
+        }
 
-		[Fact, CleanDatabase]
-		public void RemoveTimedOutServers_DoItsWorkPerfectly()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void RemoveTimedOutServers_DoItsWorkPerfectly()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""server"" (""id"", ""data"", ""lastheartbeat"")
 values (@id, '', @heartbeat)";
 
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(
-					arrangeSql,
-					new[]
-					{
-						new {id = "server1", heartbeat = DateTime.UtcNow.AddDays(-1)},
-						new {id = "server2", heartbeat = DateTime.UtcNow.AddHours(-12)}
-					});
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(
+                    arrangeSql,
+                    new[]
+                    {
+                        new {id = "server1", heartbeat = DateTime.UtcNow.AddDays(-1)},
+                        new {id = "server2", heartbeat = DateTime.UtcNow.AddHours(-12)}
+                    });
 
-				connection.RemoveTimedOutServers(TimeSpan.FromHours(15));
+                connection.RemoveTimedOutServers(TimeSpan.FromHours(15));
 
-				var liveServer = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
-				Assert.Equal("server2", liveServer.id);
-			});
-		}
+                var liveServer = sql.Query(@"select * from """ + GetSchemaName() + @""".""server""").Single();
+                Assert.Equal("server2", liveServer.id);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromSet_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-				Assert.Throws<ArgumentNullException>(() => connection.GetAllItemsFromSet(null)));
-		}
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSet_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+                Assert.Throws<ArgumentNullException>(() => connection.GetAllItemsFromSet(null)));
+        }
 
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromSet_ReturnsEmptyCollection_WhenKeyDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetAllItemsFromSet("some-set");
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSet_ReturnsEmptyCollection_WhenKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllItemsFromSet("some-set");
 
-				Assert.NotNull(result);
-				Assert.Empty(result);
-			});
-		}
+                Assert.NotNull(result);
+                Assert.Empty(result);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromSet_ReturnsAllItems()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromSet_ReturnsAllItems()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""set"" (""key"", ""score"", ""value"")
 values (@key, 0.0, @value)";
 
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new {key = "some-set", value = "1"},
-					new {key = "some-set", value = "2"},
-					new {key = "another-set", value = "3"}
-				});
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new {key = "some-set", value = "1"},
+                    new {key = "some-set", value = "2"},
+                    new {key = "another-set", value = "3"}
+                });
 
-				// Act
-				var result = connection.GetAllItemsFromSet("some-set");
+                // Act
+                var result = connection.GetAllItemsFromSet("some-set");
 
-				// Assert
-				Assert.Equal(2, result.Count);
-				Assert.Contains("1", result);
-				Assert.Contains("2", result);
-			});
-		}
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Contains("1", result);
+                Assert.Contains("2", result);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetRangeInHash_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.SetRangeInHash(null, new Dictionary<string, string>()));
+        [Fact, CleanDatabase]
+        public void SetRangeInHash_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.SetRangeInHash(null, new Dictionary<string, string>()));
 
-				Assert.Equal("key", exception.ParamName);
-			});
-		}
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetRangeInHash_ThrowsAnException_WhenKeyValuePairsArgumentIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.SetRangeInHash("some-hash", null));
+        [Fact, CleanDatabase]
+        public void SetRangeInHash_ThrowsAnException_WhenKeyValuePairsArgumentIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.SetRangeInHash("some-hash", null));
 
-				Assert.Equal("keyValuePairs", exception.ParamName);
-			});
-		}
+                Assert.Equal("keyValuePairs", exception.ParamName);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetRangeInHash_MergesAllRecords()
-		{
-			UseConnections((sql, connection) =>
-			{
-				connection.SetRangeInHash("some-hash", new Dictionary<string, string>
-				{
-					{"Key1", "Value1"},
-					{"Key2", "Value2"}
-				});
+        [Fact, CleanDatabase]
+        public void SetRangeInHash_MergesAllRecords()
+        {
+            UseConnections((sql, connection) =>
+            {
+                connection.SetRangeInHash("some-hash", new Dictionary<string, string>
+                {
+                    {"Key1", "Value1"},
+                    {"Key2", "Value2"}
+                });
 
-				var result = sql.Query(
-					@"select * from """ + GetSchemaName() + @""".""hash"" where ""key"" = @key",
-					new {key = "some-hash"})
-					.ToDictionary(x => (string) x.field, x => (string) x.value);
+                var result = sql.Query(
+                    @"select * from """ + GetSchemaName() + @""".""hash"" where ""key"" = @key",
+                    new { key = "some-hash" })
+                    .ToDictionary(x => (string)x.field, x => (string)x.value);
 
-				Assert.Equal("Value1", result["Key1"]);
-				Assert.Equal("Value2", result["Key2"]);
-			});
-		}
+                Assert.Equal("Value1", result["Key1"]);
+                Assert.Equal("Value2", result["Key2"]);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void SetRangeInHash_DoesNotThrowSerializationException()
-		{
-			Parallel.For(1, 100, (i) =>
-			{
-				UseConnection((connection2) =>
-				{
-					connection2.SetRangeInHash("some-hash", new Dictionary<string, string>
-					{
-						{"Key1", "Value1"},
-						{"Key2", "Value2"}
-					});
-				});
-			});
-		}
+        private class Converter : TextWriter
+        {
+            ITestOutputHelper _output;
+            public Converter(ITestOutputHelper output)
+            {
+                _output = output;
+            }
+            public override Encoding Encoding
+            {
+                get { return Encoding.UTF8; }
+            }
+            public override void WriteLine(string message)
+            {
+                _output.WriteLine(message);
+            }
+            public override void WriteLine(string format, params object[] args)
+            {
+                _output.WriteLine(format, args);
+            }
 
-		[Fact, CleanDatabase]
-		public void GetAllEntriesFromHash_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-				Assert.Throws<ArgumentNullException>(() => connection.GetAllEntriesFromHash(null)));
-		}
+            public override void Write(char value)
+            {
+                throw new NotSupportedException("This text writer only supports WriteLine(string) and WriteLine(string, params object[]).");
+            }
+        }
 
-		[Fact, CleanDatabase]
-		public void GetAllEntriesFromHash_ReturnsNull_IfHashDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetAllEntriesFromHash("some-hash");
-				Assert.Null(result);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void SetRangeInHash_DoesNotThrowSerializationException()
+        {
+            Console.SetOut(new Converter(_outputHelper));
+            Parallel.For(1, 100, (i) =>
+            {
+                UseConnection((connection2) =>
+                {
+                    connection2.SetRangeInHash("some-hash", new Dictionary<string, string>
+                    {
+                        {"Key1", "Value1"},
+                        {"Key2", "Value2"}
+                    });
+                });
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void GetAllEntriesFromHash_ReturnsAllKeysAndTheirValues()
-		{
-			string arrangeSql = @"
+        [Fact, CleanDatabase]
+        public void GetAllEntriesFromHash_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+                Assert.Throws<ArgumentNullException>(() => connection.GetAllEntriesFromHash(null)));
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllEntriesFromHash_ReturnsNull_IfHashDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllEntriesFromHash("some-hash");
+                Assert.Null(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllEntriesFromHash_ReturnsAllKeysAndTheirValues()
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""hash"" (""key"", ""field"", ""value"")
 values (@key, @field, @value)";
 
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new {key = "some-hash", field = "Key1", value = "Value1"},
-					new {key = "some-hash", field = "Key2", value = "Value2"},
-					new {key = "another-hash", field = "Key3", value = "Value3"}
-				});
-
-				// Act
-				var result = connection.GetAllEntriesFromHash("some-hash");
-
-				// Assert
-				Assert.NotNull(result);
-				Assert.Equal(2, result.Count);
-				Assert.Equal("Value1", result["Key1"]);
-				Assert.Equal("Value2", result["Key2"]);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetCount_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetSetCount(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetCount_ReturnsZero_WhenSetDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetSetCount("my-set");
-				Assert.Equal(0, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetCount_ReturnsNumberOfElements_InASet()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, score) values (@key, @value, 0.0)";
-
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(arrangeSql, new List<dynamic>
-				{
-					new { key = "set-1", value = "value-1" },
-					new { key = "set-2", value = "value-1" },
-					new { key = "set-1", value = "value-2" }
-				});
-
-				var result = connection.GetSetCount("set-1");
-
-				Assert.Equal(2, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromList_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetAllItemsFromList(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromList_ReturnsAnEmptyList_WhenListDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetAllItemsFromList("my-list");
-				Assert.Empty(result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetAllItemsFromList_ReturnsAllItems_FromAGivenList()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, value) values (@key, @value)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "list-1", value = "1" },
-					new { key = "list-2", value = "2" },
-					new { key = "list-1", value = "3" }
-				});
-
-				// Act
-				var result = connection.GetAllItemsFromList("list-1");
-
-				// Assert
-				Assert.Equal(new[] { "3", "1" }, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetCounter_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetCounter(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetCounter_ReturnsZero_WhenKeyDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetCounter("my-counter");
-				Assert.Equal(0, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetCounter_ReturnsSumOfValues_InCounterTable()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".counter (key, value) values (@key, @value)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "counter-1", value = 1 },
-					new { key = "counter-2", value = 1 },
-					new { key = "counter-1", value = 1 }
-				});
-
-				// Act
-				var result = connection.GetCounter("counter-1");
-
-				// Assert
-				Assert.Equal(2, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListCount_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetListCount(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListCount_ReturnsZero_WhenListDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetListCount("my-list");
-				Assert.Equal(0, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListCount_ReturnsTheNumberOfListElements()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key) values (@key)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "list-1" },
-					new { key = "list-1" },
-					new { key = "list-2" }
-				});
-
-				// Act
-				var result = connection.GetListCount("list-1");
-
-				// Assert
-				Assert.Equal(2, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListTtl_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetListTtl(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListTtl_ReturnsNegativeValue_WhenListDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetListTtl("my-list");
-				Assert.True(result < TimeSpan.Zero);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetListTtl_ReturnsExpirationTimeForList()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, expireat) values (@key, @expireAt)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "list-1", expireAt = (DateTime?) DateTime.UtcNow.AddHours(1) },
-					new { key = "list-2", expireAt = (DateTime?) null }
-				});
-
-				// Act
-				var result = connection.GetListTtl("list-1");
-
-				// Assert
-				Assert.True(TimeSpan.FromMinutes(59) < result);
-				Assert.True(result < TimeSpan.FromMinutes(61));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetRangeFromList_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetRangeFromList(null, 0, 1));
-
-				Assert.Equal("key", exception.ParamName);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetRangeFromList_ReturnsAnEmptyList_WhenListDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetRangeFromList("my-list", 0, 1);
-				Assert.Empty(result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetRangeFromList_ReturnsAllEntries_WithinGivenBounds()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, value) values (@key, @value)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "list-1", value = "1" },
-					new { key = "list-2", value = "2" },
-					new { key = "list-1", value = "3" },
-					new { key = "list-1", value = "4" },
-					new { key = "list-1", value = "5" }
-				});
-
-				// Act
-				var result = connection.GetRangeFromList("list-1", 1, 2);
-
-				// Assert
-				Assert.Equal(new[] { "4", "3" }, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashCount_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(() => connection.GetHashCount(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashCount_ReturnsZero_WhenKeyDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetHashCount("my-hash");
-				Assert.Equal(0, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashCount_ReturnsNumber_OfHashFields()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field) values (@key, @field)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "hash-1", field = "field-1" },
-					new { key = "hash-1", field = "field-2" },
-					new { key = "hash-2", field = "field-1" }
-				});
-
-				// Act
-				var result = connection.GetHashCount("hash-1");
-
-				// Assert
-				Assert.Equal(2, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashTtl_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(
-					() => connection.GetHashTtl(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashTtl_ReturnsNegativeValue_WhenHashDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetHashTtl("my-hash");
-				Assert.True(result < TimeSpan.Zero);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetHashTtl_ReturnsExpirationTimeForHash()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field, expireat) values (@key, @field, @expireAt)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "hash-1", field = "field", expireAt = (DateTime?)DateTime.UtcNow.AddHours(1) },
-					new { key = "hash-2", field = "field", expireAt = (DateTime?) null }
-				});
-
-				// Act
-				var result = connection.GetHashTtl("hash-1");
-
-				// Assert
-				Assert.True(TimeSpan.FromMinutes(59) < result);
-				Assert.True(result < TimeSpan.FromMinutes(61));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetRangeFromSet_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(() => connection.GetRangeFromSet(null, 0, 1));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetRangeFromSet_ReturnsPagedElements()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, score) values (@key, @value, 0.0)";
-
-			UseConnections((sql, connection) =>
-			{
-				sql.Execute(arrangeSql, new List<dynamic>
-				{
-					new { key = "set-1", value = "1" },
-					new { key = "set-1", value = "2" },
-					new { key = "set-1", value = "3" },
-					new { key = "set-1", value = "4" },
-					new { key = "set-2", value = "4" },
-					new { key = "set-1", value = "5" }
-				});
-
-				var result = connection.GetRangeFromSet("set-1", 2, 3);
-
-				Assert.Equal(new[] { "3", "4" }, result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetTtl_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				Assert.Throws<ArgumentNullException>(() => connection.GetSetTtl(null));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetTtl_ReturnsNegativeValue_WhenSetDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetSetTtl("my-set");
-				Assert.True(result < TimeSpan.Zero);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetSetTtl_ReturnsExpirationTime_OfAGivenSet()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, expireat, score) values (@key, @value, @expireAt, 0.0)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "set-1", value = "1", expireAt = (DateTime?) DateTime.UtcNow.AddMinutes(60) },
-					new { key = "set-2", value = "2", expireAt = (DateTime?) null }
-				});
-
-				// Act
-				var result = connection.GetSetTtl("set-1");
-
-				// Assert
-				Assert.True(TimeSpan.FromMinutes(59) < result);
-				Assert.True(result < TimeSpan.FromMinutes(61));
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetValueFromHash_ThrowsAnException_WhenKeyIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetValueFromHash(null, "name"));
-
-				Assert.Equal("key", exception.ParamName);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetValueFromHash_ThrowsAnException_WhenNameIsNull()
-		{
-			UseConnection(connection =>
-			{
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => connection.GetValueFromHash("key", null));
-
-				Assert.Equal("name", exception.ParamName);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetValueFromHash_ReturnsNull_WhenHashDoesNotExist()
-		{
-			UseConnection(connection =>
-			{
-				var result = connection.GetValueFromHash("my-hash", "name");
-				Assert.Null(result);
-			});
-		}
-
-		[Fact, CleanDatabase]
-		public void GetValueFromHash_ReturnsValue_OfAGivenField()
-		{
-			string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field, value) values (@key, @field, @value)";
-
-			UseConnections((sql, connection) =>
-			{
-				// Arrange
-				sql.Execute(arrangeSql, new[]
-				{
-					new { key = "hash-1", field = "field-1", value = "1" },
-					new { key = "hash-1", field = "field-2", value = "2" },
-					new { key = "hash-2", field = "field-1", value = "3" }
-				});
-
-				// Act
-				var result = connection.GetValueFromHash("hash-1", "field-1");
-
-				// Assert
-				Assert.Equal("1", result);
-			});
-		}
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new {key = "some-hash", field = "Key1", value = "Value1"},
+                    new {key = "some-hash", field = "Key2", value = "Value2"},
+                    new {key = "another-hash", field = "Key3", value = "Value3"}
+                });
+
+                // Act
+                var result = connection.GetAllEntriesFromHash("some-hash");
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(2, result.Count);
+                Assert.Equal("Value1", result["Key1"]);
+                Assert.Equal("Value2", result["Key2"]);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetCount_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetSetCount(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetCount_ReturnsZero_WhenSetDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetSetCount("my-set");
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetCount_ReturnsNumberOfElements_InASet()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, score) values (@key, @value, 0.0)";
+
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql, new List<dynamic>
+                {
+                    new { key = "set-1", value = "value-1" },
+                    new { key = "set-2", value = "value-1" },
+                    new { key = "set-1", value = "value-2" }
+                });
+
+                var result = connection.GetSetCount("set-1");
+
+                Assert.Equal(2, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromList_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetAllItemsFromList(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromList_ReturnsAnEmptyList_WhenListDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetAllItemsFromList("my-list");
+                Assert.Empty(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetAllItemsFromList_ReturnsAllItems_FromAGivenList()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, value) values (@key, @value)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "list-1", value = "1" },
+                    new { key = "list-2", value = "2" },
+                    new { key = "list-1", value = "3" }
+                });
+
+                // Act
+                var result = connection.GetAllItemsFromList("list-1");
+
+                // Assert
+                Assert.Equal(new[] { "3", "1" }, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetCounter_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetCounter(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetCounter_ReturnsZero_WhenKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetCounter("my-counter");
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetCounter_ReturnsSumOfValues_InCounterTable()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".counter (key, value) values (@key, @value)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "counter-1", value = 1 },
+                    new { key = "counter-2", value = 1 },
+                    new { key = "counter-1", value = 1 }
+                });
+
+                // Act
+                var result = connection.GetCounter("counter-1");
+
+                // Assert
+                Assert.Equal(2, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListCount_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetListCount(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListCount_ReturnsZero_WhenListDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetListCount("my-list");
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListCount_ReturnsTheNumberOfListElements()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key) values (@key)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "list-1" },
+                    new { key = "list-1" },
+                    new { key = "list-2" }
+                });
+
+                // Act
+                var result = connection.GetListCount("list-1");
+
+                // Assert
+                Assert.Equal(2, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListTtl_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetListTtl(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListTtl_ReturnsNegativeValue_WhenListDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetListTtl("my-list");
+                Assert.True(result < TimeSpan.Zero);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetListTtl_ReturnsExpirationTimeForList()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, expireat) values (@key, @expireAt)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "list-1", expireAt = (DateTime?) DateTime.UtcNow.AddHours(1) },
+                    new { key = "list-2", expireAt = (DateTime?) null }
+                });
+
+                // Act
+                var result = connection.GetListTtl("list-1");
+
+                // Assert
+                Assert.True(TimeSpan.FromMinutes(59) < result);
+                Assert.True(result < TimeSpan.FromMinutes(61));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetRangeFromList_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetRangeFromList(null, 0, 1));
+
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetRangeFromList_ReturnsAnEmptyList_WhenListDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetRangeFromList("my-list", 0, 1);
+                Assert.Empty(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetRangeFromList_ReturnsAllEntries_WithinGivenBounds()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".list (key, value) values (@key, @value)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "list-1", value = "1" },
+                    new { key = "list-2", value = "2" },
+                    new { key = "list-1", value = "3" },
+                    new { key = "list-1", value = "4" },
+                    new { key = "list-1", value = "5" }
+                });
+
+                // Act
+                var result = connection.GetRangeFromList("list-1", 1, 2);
+
+                // Assert
+                Assert.Equal(new[] { "4", "3" }, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashCount_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(() => connection.GetHashCount(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashCount_ReturnsZero_WhenKeyDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetHashCount("my-hash");
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashCount_ReturnsNumber_OfHashFields()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field) values (@key, @field)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "hash-1", field = "field-1" },
+                    new { key = "hash-1", field = "field-2" },
+                    new { key = "hash-2", field = "field-1" }
+                });
+
+                // Act
+                var result = connection.GetHashCount("hash-1");
+
+                // Assert
+                Assert.Equal(2, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashTtl_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetHashTtl(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashTtl_ReturnsNegativeValue_WhenHashDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetHashTtl("my-hash");
+                Assert.True(result < TimeSpan.Zero);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetHashTtl_ReturnsExpirationTimeForHash()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field, expireat) values (@key, @field, @expireAt)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "hash-1", field = "field", expireAt = (DateTime?)DateTime.UtcNow.AddHours(1) },
+                    new { key = "hash-2", field = "field", expireAt = (DateTime?) null }
+                });
+
+                // Act
+                var result = connection.GetHashTtl("hash-1");
+
+                // Assert
+                Assert.True(TimeSpan.FromMinutes(59) < result);
+                Assert.True(result < TimeSpan.FromMinutes(61));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetRangeFromSet_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(() => connection.GetRangeFromSet(null, 0, 1));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetRangeFromSet_ReturnsPagedElements()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, score) values (@key, @value, 0.0)";
+
+            UseConnections((sql, connection) =>
+            {
+                sql.Execute(arrangeSql, new List<dynamic>
+                {
+                    new { key = "set-1", value = "1" },
+                    new { key = "set-1", value = "2" },
+                    new { key = "set-1", value = "3" },
+                    new { key = "set-1", value = "4" },
+                    new { key = "set-2", value = "4" },
+                    new { key = "set-1", value = "5" }
+                });
+
+                var result = connection.GetRangeFromSet("set-1", 2, 3);
+
+                Assert.Equal(new[] { "3", "4" }, result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetTtl_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                Assert.Throws<ArgumentNullException>(() => connection.GetSetTtl(null));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetTtl_ReturnsNegativeValue_WhenSetDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetSetTtl("my-set");
+                Assert.True(result < TimeSpan.Zero);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetSetTtl_ReturnsExpirationTime_OfAGivenSet()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".set (key, value, expireat, score) values (@key, @value, @expireAt, 0.0)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "set-1", value = "1", expireAt = (DateTime?) DateTime.UtcNow.AddMinutes(60) },
+                    new { key = "set-2", value = "2", expireAt = (DateTime?) null }
+                });
+
+                // Act
+                var result = connection.GetSetTtl("set-1");
+
+                // Assert
+                Assert.True(TimeSpan.FromMinutes(59) < result);
+                Assert.True(result < TimeSpan.FromMinutes(61));
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetValueFromHash_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetValueFromHash(null, "name"));
+
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetValueFromHash_ThrowsAnException_WhenNameIsNull()
+        {
+            UseConnection(connection =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetValueFromHash("key", null));
+
+                Assert.Equal("name", exception.ParamName);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetValueFromHash_ReturnsNull_WhenHashDoesNotExist()
+        {
+            UseConnection(connection =>
+            {
+                var result = connection.GetValueFromHash("my-hash", "name");
+                Assert.Null(result);
+            });
+        }
+
+        [Fact, CleanDatabase]
+        public void GetValueFromHash_ReturnsValue_OfAGivenField()
+        {
+            string arrangeSql = $@"insert into ""{GetSchemaName()}"".hash (key, field, value) values (@key, @field, @value)";
+
+            UseConnections((sql, connection) =>
+            {
+                // Arrange
+                sql.Execute(arrangeSql, new[]
+                {
+                    new { key = "hash-1", field = "field-1", value = "1" },
+                    new { key = "hash-1", field = "field-2", value = "2" },
+                    new { key = "hash-2", field = "field-1", value = "3" }
+                });
+
+                // Act
+                var result = connection.GetValueFromHash("hash-1", "field-1");
+
+                // Assert
+                Assert.Equal("1", result);
+            });
+        }
 
         [Theory, CleanDatabase]
         [InlineData(false)]
@@ -1390,34 +1391,29 @@ values (@key, @field, @value)";
         }
 
         private void UseConnections(Action<NpgsqlConnection, PostgreSqlConnection> action)
-		{
-			using (var sqlConnection = ConnectionUtils.CreateConnection())
-			using (var connection = new PostgreSqlConnection(sqlConnection, _providers, _options))
-			{
-				action(sqlConnection, connection);
-			}
-		}
+        {
+            _fixture.SafeInit(_options, _providers);
+            var connection = new PostgreSqlConnection(Storage);
+            action(Storage.CreateAndOpenConnection(), connection);
+        }
 
-		private void UseConnection(Action<PostgreSqlConnection> action)
-		{
-			using (var connection = new PostgreSqlConnection(
-				ConnectionUtils.CreateConnection(),
-				_providers,
-				_options))
-			{
-				action(connection);
-			}
-		}
+        private void UseConnection(Action<PostgreSqlConnection> action)
+        {
+            _fixture.SafeInit(_options, _providers);
+            _fixture.Storage.QueueProviders = _providers;
+            var connection = new PostgreSqlConnection(Storage);
+            action(connection);
+        }
 
-		private static string GetSchemaName()
-		{
-			return ConnectionUtils.GetSchemaName();
-		}
+        private static string GetSchemaName()
+        {
+            return ConnectionUtils.GetSchemaName();
+        }
 
 #pragma warning disable xUnit1013 // Public method should be marked as test
-		public static void SampleMethod(string arg)
+        public static void SampleMethod(string arg)
 #pragma warning restore xUnit1013 // Public method should be marked as test
-		{
-		}
-	}
+        {
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
@@ -10,9 +10,15 @@ using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-    public class PostgreSqlDistributedLockFacts
+    public class PostgreSqlDistributedLockFacts : IDisposable
     {
         private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
+        private NpgsqlConnection _connection;
+
+        public void Dispose()
+        {
+            _connection?.Dispose();
+        }
 
         [Fact]
         public void Acquire_ThrowsAnException_WhenResourceIsNullOrEmpty()
@@ -232,13 +238,10 @@ namespace Hangfire.PostgreSql.Tests
             });
         }
 
-
         private void UseConnection(Action<NpgsqlConnection> action)
         {
-            using (var connection = ConnectionUtils.CreateConnection())
-            {
-                action(connection);
-            }
+            _connection = _connection ?? ConnectionUtils.CreateConnection();
+            action(_connection);
         }
 
         private static string GetSchemaName()

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using Dapper;
+using Moq;
+using Npgsql;
+using System;
 using System.Data;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Threading;
-using Dapper;
-using Moq;
-using Npgsql;
 using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
@@ -16,39 +15,41 @@ namespace Hangfire.PostgreSql.Tests
         private readonly TimeSpan _timeout = TimeSpan.FromSeconds(5);
 
         [Fact]
-        public void Ctor_ThrowsAnException_WhenResourceIsNullOrEmpty()
+        public void Acquire_ThrowsAnException_WhenResourceIsNullOrEmpty()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
 
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PostgreSqlDistributedLock("", _timeout, new Mock<IDbConnection>().Object, options));
+                () => PostgreSqlDistributedLock.Acquire(new Mock<IDbConnection>().Object, "", _timeout, options));
 
             Assert.Equal("resource", exception.ParamName);
         }
 
         [Fact]
-        public void Ctor_ThrowsAnException_WhenConnectionIsNull()
+        public void Acquire_ThrowsAnException_WhenConnectionIsNull()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions();
 
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PostgreSqlDistributedLock("hello", _timeout, null, options));
+                () => PostgreSqlDistributedLock.Acquire(null, "hello", _timeout, options));
 
             Assert.Equal("connection", exception.ParamName);
         }
 
         [Fact]
-        public void Ctor_ThrowsAnException_WhenOptionsIsNull()
+        public void Acquire_ThrowsAnException_WhenOptionsIsNull()
         {
+            var connection = new Mock<IDbConnection>();
+            connection.SetupGet(c => c.State).Returns(ConnectionState.Open);
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PostgreSqlDistributedLock("hi", _timeout, new Mock<IDbConnection>().Object, null));
+                () => PostgreSqlDistributedLock.Acquire(new Mock<IDbConnection>().Object, "hi", _timeout, null));
 
             Assert.Equal("options", exception.ParamName);
         }
 
 
         [Fact, CleanDatabase]
-        public void Ctor_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession()
+        public void Acquire_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
             {
@@ -59,7 +60,7 @@ namespace Hangfire.PostgreSql.Tests
             UseConnection(connection =>
             {
                 // ReSharper disable once UnusedVariable
-                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
+                PostgreSqlDistributedLock.Acquire(connection, "hello", _timeout, options);
 
                 var lockCount = connection.Query<long>(
                     @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
@@ -71,7 +72,7 @@ namespace Hangfire.PostgreSql.Tests
         }
 
         [Fact, CleanDatabase]
-        public void Ctor_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession_WhenDeadlockIsOccured()
+        public void Acquire_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession_WhenDeadlockIsOccured()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
             {
@@ -79,7 +80,7 @@ namespace Hangfire.PostgreSql.Tests
                 UseNativeDatabaseTransactions = true,
                 DistributedLockTimeout = TimeSpan.FromSeconds(10)
             };
-            
+
             UseConnection(connection =>
             {
                 // Arrange
@@ -88,16 +89,13 @@ namespace Hangfire.PostgreSql.Tests
                 var dateTimeNow = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture);
                 connection.Execute($@"INSERT INTO ""{GetSchemaName()}"".""lock"" VALUES ('{resourceName}', 0, '{dateTimeNow}')");
 
-                // Act
-                var distributedLock = new PostgreSqlDistributedLock(resourceName, timeout, connection, options);
-
-                // Assert
-                Assert.True(distributedLock != null);
+                // Act && Assert (not throwing means it worked)
+                PostgreSqlDistributedLock.Acquire(connection, resourceName, timeout, options);
             });
         }
 
         [Fact, CleanDatabase]
-        public void Ctor_AcquiresExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions_OnSession()
+        public void Acquire_AcquiresExclusiveApplicationLock_WithoutUseNativeDatabaseTransactions_OnSession()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
             {
@@ -110,8 +108,8 @@ namespace Hangfire.PostgreSql.Tests
                 // ReSharper disable UnusedVariable
 
                 // Acquire locks on two different resources to make sure they don't conflict.
-                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-                var distributedLock2 = new PostgreSqlDistributedLock("hello2", _timeout, connection, options);
+                PostgreSqlDistributedLock.Acquire(connection, "hello", _timeout, options);
+                PostgreSqlDistributedLock.Acquire(connection, "hello2", _timeout, options);
 
                 // ReSharper restore UnusedVariable
 
@@ -126,7 +124,7 @@ namespace Hangfire.PostgreSql.Tests
 
 
         [Fact, CleanDatabase]
-        public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithUseNativeDatabaseTransactions()
+        public void Acquire_ThrowsAnException_IfLockCanNotBeGranted_WithUseNativeDatabaseTransactions()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
             {
@@ -140,11 +138,10 @@ namespace Hangfire.PostgreSql.Tests
             var thread = new Thread(
                 () => UseConnection(connection1 =>
                 {
-                    using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
-                    {
-                        lockAcquired.Set();
-                        releaseLock.Wait();
-                    }
+                    PostgreSqlDistributedLock.Acquire(connection1, "exclusive", _timeout, options);
+                    lockAcquired.Set();
+                    releaseLock.Wait();
+                    PostgreSqlDistributedLock.Release(connection1, "exclusive", options);
                 }));
             thread.Start();
 
@@ -152,14 +149,14 @@ namespace Hangfire.PostgreSql.Tests
 
             UseConnection(connection2 =>
                 Assert.Throws<PostgreSqlDistributedLockException>(
-                    () => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
+                    () => PostgreSqlDistributedLock.Acquire(connection2, "exclusive", _timeout, options)));
 
             releaseLock.Set();
             thread.Join();
         }
 
         [Fact, CleanDatabase]
-        public void Ctor_ThrowsAnException_IfLockCanNotBeGranted_WithoutUseNativeDatabaseTransactions()
+        public void Acquire_ThrowsAnException_IfLockCanNotBeGranted_WithoutUseNativeDatabaseTransactions()
         {
             PostgreSqlStorageOptions options = new PostgreSqlStorageOptions()
             {
@@ -173,11 +170,10 @@ namespace Hangfire.PostgreSql.Tests
             var thread = new Thread(
                 () => UseConnection(connection1 =>
                 {
-                    using (new PostgreSqlDistributedLock("exclusive", _timeout, connection1, options))
-                    {
-                        lockAcquired.Set();
-                        releaseLock.Wait();
-                    }
+                    PostgreSqlDistributedLock.Acquire(connection1, "exclusive", _timeout, options);
+                    lockAcquired.Set();
+                    releaseLock.Wait();
+                    PostgreSqlDistributedLock.Release(connection1, "exclusive", options);
                 }));
             thread.Start();
 
@@ -185,7 +181,7 @@ namespace Hangfire.PostgreSql.Tests
 
             UseConnection(connection2 =>
                 Assert.Throws<PostgreSqlDistributedLockException>(
-                    () => new PostgreSqlDistributedLock("exclusive", _timeout, connection2, options)));
+                    () => PostgreSqlDistributedLock.Acquire(connection2, "exclusive", _timeout, options)));
 
             releaseLock.Set();
             thread.Join();
@@ -203,8 +199,8 @@ namespace Hangfire.PostgreSql.Tests
 
             UseConnection(connection =>
             {
-                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-                distributedLock.Dispose();
+                PostgreSqlDistributedLock.Acquire(connection, "hello", _timeout, options);
+                PostgreSqlDistributedLock.Release(connection, "hello", options);
 
                 var lockCount = connection.Query<long>(
                     @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",
@@ -225,8 +221,8 @@ namespace Hangfire.PostgreSql.Tests
 
             UseConnection(connection =>
             {
-                var distributedLock = new PostgreSqlDistributedLock("hello", _timeout, connection, options);
-                distributedLock.Dispose();
+                PostgreSqlDistributedLock.Acquire(connection, "hello", _timeout, options);
+                PostgreSqlDistributedLock.Release(connection, "hello", options);
 
                 var lockCount = connection.Query<long>(
                     @"select count(*) from """ + GetSchemaName() + @""".""lock"" where ""resource"" = @resource",

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
@@ -11,12 +11,10 @@ namespace Hangfire.PostgreSql.Tests
         private const string JobId = "id";
         private const string Queue = "queue";
 
-        private readonly PostgreSqlStorageOptions _options;
-        private PostgreSqlStorage _storage;
+        private readonly PostgreSqlStorage _storage;
 
         public PostgreSqlFetchedJobFacts()
         {
-            _options = new PostgreSqlStorageOptions();
             _storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
         }
 

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
@@ -1,157 +1,145 @@
-﻿using System;
-using System.Data;
+﻿using Dapper;
+using System;
 using System.Globalization;
 using System.Linq;
-using Dapper;
-using Moq;
-using Npgsql;
 using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlFetchedJobFacts
-	{
-		private const string JobId = "id";
-		private const string Queue = "queue";
+    public class PostgreSqlFetchedJobFacts
+    {
+        private const string JobId = "id";
+        private const string Queue = "queue";
 
-		private readonly PostgreSqlStorageOptions _options;
-		private PostgreSqlStorage _storage;
+        private readonly PostgreSqlStorageOptions _options;
+        private PostgreSqlStorage _storage;
 
-		public PostgreSqlFetchedJobFacts()
-		{
-			_options = new PostgreSqlStorageOptions();
-			_storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
-		}
+        public PostgreSqlFetchedJobFacts()
+        {
+            _options = new PostgreSqlStorageOptions();
+            _storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenConnectionIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlFetchedJob(null, new PostgreSqlStorageOptions(), 1, JobId, Queue));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenStorageIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlFetchedJob(null, 1, JobId, Queue));
 
-			Assert.Equal("storage", exception.ParamName);
-		}
+            Assert.Equal("storage", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenOptionsIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlFetchedJob(_storage, null, 1, JobId, Queue));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenJobIdIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlFetchedJob(_storage, 1, null, Queue));
 
-			Assert.Equal("options", exception.ParamName);
-		}
+            Assert.Equal("jobId", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenJobIdIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlFetchedJob(_storage, _options, 1, null, Queue));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenQueueIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlFetchedJob(_storage, 1, JobId, null));
 
-			Assert.Equal("jobId", exception.ParamName);
-		}
+            Assert.Equal("queue", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenQueueIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlFetchedJob(_storage, _options, 1, JobId, null));
+        [Fact]
+        public void Ctor_CorrectlySets_AllInstanceProperties()
+        {
+            var fetchedJob = new PostgreSqlFetchedJob(_storage, 1, JobId, Queue);
 
-			Assert.Equal("queue", exception.ParamName);
-		}
+            Assert.Equal(1, fetchedJob.Id);
+            Assert.Equal(JobId, fetchedJob.JobId);
+            Assert.Equal(Queue, fetchedJob.Queue);
+        }
 
-		[Fact]
-		public void Ctor_CorrectlySets_AllInstanceProperties()
-		{
-			var fetchedJob = new PostgreSqlFetchedJob(_storage, _options, 1, JobId, Queue);
+        [Fact, CleanDatabase]
+        public void RemoveFromQueue_ReallyDeletesTheJobFromTheQueue()
+        {
+            // Arrange
+            var id = CreateJobQueueRecord(_storage, "1", "default");
+            var processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default");
 
-			Assert.Equal(1, fetchedJob.Id);
-			Assert.Equal(JobId, fetchedJob.JobId);
-			Assert.Equal(Queue, fetchedJob.Queue);
-		}
+            // Act
+            processingJob.RemoveFromQueue();
 
-		[Fact, CleanDatabase]
-		public void RemoveFromQueue_ReallyDeletesTheJobFromTheQueue()
-		{
-			// Arrange
-			var id = CreateJobQueueRecord(_storage, "1", "default");
-			var processingJob = new PostgreSqlFetchedJob(_storage, _options, id, "1", "default");
+            // Assert
+            var count = _storage.UseConnection(null, connection =>
+                connection.Query<long>(@"select count(*) from """ + GetSchemaName() + @""".""jobqueue""").Single());
+            Assert.Equal(0, count);
+        }
 
-			// Act
-			processingJob.RemoveFromQueue();
+        [Fact, CleanDatabase]
+        public void RemoveFromQueue_DoesNotDelete_UnrelatedJobs()
+        {
+            // Arrange
+            CreateJobQueueRecord(_storage, "1", "default");
+            CreateJobQueueRecord(_storage, "1", "critical");
+            CreateJobQueueRecord(_storage, "2", "default");
 
-			// Assert
-			var count = _storage.UseConnection(connection =>
-				connection.Query<long>(@"select count(*) from """ + GetSchemaName() + @""".""jobqueue""").Single());
-			Assert.Equal(0, count);
-		}
+            var fetchedJob = new PostgreSqlFetchedJob(_storage, 999, "1", "default");
 
-		[Fact, CleanDatabase]
-		public void RemoveFromQueue_DoesNotDelete_UnrelatedJobs()
-		{
-			// Arrange
-			CreateJobQueueRecord(_storage, "1", "default");
-			CreateJobQueueRecord(_storage, "1", "critical");
-			CreateJobQueueRecord(_storage, "2", "default");
+            // Act
+            fetchedJob.RemoveFromQueue();
 
-			var fetchedJob = new PostgreSqlFetchedJob(_storage, _options, 999, "1", "default");
+            // Assert
+            var count = _storage.UseConnection(null, connection =>
+                connection.Query<long>(@"select count(*) from """ + GetSchemaName() + @""".""jobqueue""").Single());
+            Assert.Equal(3, count);
+        }
 
-			// Act
-			fetchedJob.RemoveFromQueue();
+        [Fact, CleanDatabase]
+        public void Requeue_SetsFetchedAtValueToNull()
+        {
+            // Arrange
+            var id = CreateJobQueueRecord(_storage, "1", "default");
+            var processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default");
 
-			// Assert
-			var count = _storage.UseConnection(connection =>
-				connection.Query<long>(@"select count(*) from """ + GetSchemaName() + @""".""jobqueue""").Single());
-			Assert.Equal(3, count);
-		}
+            // Act
+            processingJob.Requeue();
 
-		[Fact, CleanDatabase]
-		public void Requeue_SetsFetchedAtValueToNull()
-		{
-			// Arrange
-			var id = CreateJobQueueRecord(_storage, "1", "default");
-			var processingJob = new PostgreSqlFetchedJob(_storage, _options, id, "1", "default");
+            // Assert
+            var record = _storage.UseConnection(null, connection =>
+                connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single());
+            Assert.Null(record.FetchedAt);
+        }
 
-			// Act
-			processingJob.Requeue();
+        [Fact, CleanDatabase]
+        public void Dispose_SetsFetchedAtValueToNull_IfThereWereNoCallsToComplete()
+        {
+            // Arrange
+            var id = CreateJobQueueRecord(_storage, "1", "default");
+            var processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default");
 
-			// Assert
-			var record = _storage.UseConnection(connection =>
-				connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single());
-			Assert.Null(record.FetchedAt);
-		}
+            // Act
+            processingJob.Dispose();
 
-		[Fact, CleanDatabase]
-		public void Dispose_SetsFetchedAtValueToNull_IfThereWereNoCallsToComplete()
-		{
-			// Arrange
-			var id = CreateJobQueueRecord(_storage, "1", "default");
-			var processingJob = new PostgreSqlFetchedJob(_storage, _options, id, "1", "default");
+            // Assert
+            var record = _storage.UseConnection(null, connection =>
+                connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single());
+            Assert.Null(record.fetchedat);
+        }
 
-			// Act
-			processingJob.Dispose();
-
-			// Assert
-			var record = _storage.UseConnection(connection =>
-				connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single());
-			Assert.Null(record.fetchedat);
-		}
-
-		private static long CreateJobQueueRecord(PostgreSqlStorage storage, string jobId, string queue)
-		{
-			string arrangeSql = @"
+        private static long CreateJobQueueRecord(PostgreSqlStorage storage, string jobId, string queue)
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"", ""fetchedat"")
 values (@id, @queue, now() at time zone 'utc') returning ""id""";
 
-			return
-				(long)
-					storage.UseConnection(connection => connection.Query(arrangeSql, new {id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue})
-						.Single()
-						.id);
-		}
+            return
+                (long)
+                    storage.UseConnection(null, connection => connection.Query(arrangeSql, new { id = Convert.ToInt32(jobId, CultureInfo.InvariantCulture), queue = queue })
+                        .Single()
+                        .id);
+        }
 
-		private static string GetSchemaName()
-		{
-			return ConnectionUtils.GetSchemaName();
-		}
-	}
+        private static string GetSchemaName()
+        {
+            return ConnectionUtils.GetSchemaName();
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -10,9 +10,16 @@ using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-    public class PostgreSqlJobQueueFacts
+    public class PostgreSqlJobQueueFacts : IClassFixture<PostgreSqlStorageFixture>
     {
         private static readonly string[] DefaultQueues = { "default" };
+
+        private readonly PostgreSqlStorageFixture _fixture;
+
+        public PostgreSqlJobQueueFacts(PostgreSqlStorageFixture fixture)
+        {
+            _fixture = fixture;
+        }
 
         [Fact]
         public void Ctor_ThrowsAnException_WhenStorageIsNull()
@@ -500,10 +507,9 @@ select i.""id"", @queue from i;
             return new PostgreSqlJobQueue(storage);
         }
 
-        private static void UseConnection(Action<IDbConnection, PostgreSqlStorage> action)
+        private void UseConnection(Action<IDbConnection, PostgreSqlStorage> action)
         {
-            var storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
-
+            var storage = _fixture.SafeInit();
             storage.UseConnection(null, connection =>
             {
                 action(connection, storage);

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -1,51 +1,41 @@
-﻿using System;
+﻿using Dapper;
+using Hangfire.Storage;
+using System;
 using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dapper;
-using Hangfire.Storage;
-using Npgsql;
 using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlJobQueueFacts
-	{
-		private static readonly string[] DefaultQueues = {"default"};
+    public class PostgreSqlJobQueueFacts
+    {
+        private static readonly string[] DefaultQueues = { "default" };
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenConnectionIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlJobQueue(null, new PostgreSqlStorageOptions()));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenStorageIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlJobQueue(null));
 
-			Assert.Equal("storage", exception.ParamName);
-		}
+            Assert.Equal("storage", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenOptionsValueIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlJobQueue(new PostgreSqlStorage(ConnectionUtils.GetConnectionString()), null));
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsNull()
+        {
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, false);
 
-			Assert.Equal("options", exception.ParamName);
-		}
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => queue.Dequeue(null, CreateTimingOutCancellationToken()));
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsNull()
-		{
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, false);
-
-				var exception = Assert.Throws<ArgumentNullException>(
-					() => queue.Dequeue(null, CreateTimingOutCancellationToken()));
-
-				Assert.Equal("queues", exception.ParamName);
-			});
-		}
+                Assert.Equal("queues", exception.ParamName);
+            });
+        }
 
         [Fact, CleanDatabase]
         public void Dequeue_ShouldFetchAJob_FromQueueWithHigherPriority()
@@ -66,135 +56,135 @@ namespace Hangfire.PostgreSql.Tests
         }
 
         [Fact, CleanDatabase]
-		private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(true);
-		}
+        private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(true);
+        }
 
-		[Fact, CleanDatabase]
-		private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(false);
-		}
+        [Fact, CleanDatabase]
+        private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(false);
+        }
 
-		private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(bool useNativeDatabaseTransactions)
-		{
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+        private void Dequeue_ShouldThrowAnException_WhenQueuesCollectionIsEmpty(bool useNativeDatabaseTransactions)
+        {
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				var exception = Assert.Throws<ArgumentException>(
-					() => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
+                var exception = Assert.Throws<ArgumentException>(
+                    () => queue.Dequeue(new string[0], CreateTimingOutCancellationToken()));
 
-				Assert.Equal("queues", exception.ParamName);
-			});
-		}
+                Assert.Equal("queues", exception.ParamName);
+            });
+        }
 
-		[Fact]
-		private void
-			Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(true);
-		}
+        [Fact]
+        private void
+            Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(true);
+        }
 
-		[Fact]
-		private void
-			Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(false);
-		}
+        [Fact]
+        private void
+            Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(false);
+        }
 
-		private void Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(
-			bool useNativeDatabaseTransactions)
-		{
-			UseConnection((connection, storage) =>
-			{
-				var cts = new CancellationTokenSource();
-				cts.Cancel();
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+        private void Dequeue_ThrowsOperationCanceled_WhenCancellationTokenIsSetAtTheBeginning(
+            bool useNativeDatabaseTransactions)
+        {
+            UseConnection((connection, storage) =>
+            {
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				Assert.Throws<OperationCanceledException>(
-					() => queue.Dequeue(DefaultQueues, cts.Token));
-			});
-		}
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(DefaultQueues, cts.Token));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(false);
+        }
 
-		private void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(bool useNativeDatabaseTransactions)
-		{
-			UseConnection((connection, storage) =>
-			{
-				var cts = new CancellationTokenSource(200);
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+        private void Dequeue_ShouldWaitIndefinitely_WhenThereAreNoJobs(bool useNativeDatabaseTransactions)
+        {
+            UseConnection((connection, storage) =>
+            {
+                var cts = new CancellationTokenSource(200);
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				Assert.Throws<OperationCanceledException>(
-					() => queue.Dequeue(DefaultQueues, cts.Token));
-			});
-		}
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(DefaultQueues, cts.Token));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(false);
+        }
 
-		private void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldFetchAJob_FromTheSpecifiedQueue(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"")
 values (@jobId, @queue) returning ""id""";
 
-			// Arrange
-			UseConnection((connection, storage) =>
-			{
-				var id = (long) connection.Query(
-					arrangeSql,
-					new {jobId = 1, queue = "default"}).Single().id;
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+            // Arrange
+            UseConnection((connection, storage) =>
+            {
+                var id = (long)connection.Query(
+                    arrangeSql,
+                    new { jobId = 1, queue = "default" }).Single().id;
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				// Act
-				var payload = (PostgreSqlFetchedJob) queue.Dequeue(
-					DefaultQueues,
-					CreateTimingOutCancellationToken());
+                // Act
+                var payload = (PostgreSqlFetchedJob)queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
 
-				// Assert
-				Assert.Equal(id, payload.Id);
-				Assert.Equal("1", payload.JobId);
-				Assert.Equal("default", payload.Queue);
-			});
-		}
+                // Assert
+                Assert.Equal(id, payload.Id);
+                Assert.Equal("1", payload.JobId);
+                Assert.Equal("default", payload.Queue);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(false);
+        }
 
-		private void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldLeaveJobInTheQueue_ButSetItsFetchedAtValue(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 WITH i AS (
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values (@invocationData, @arguments, now() at time zone 'utc')
@@ -203,46 +193,46 @@ insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"")
 select i.""id"", @queue from i;
 ";
 
-			// Arrange
-			UseConnection((connection, storage) =>
-			{
-				connection.Execute(
-					arrangeSql,
-					new {invocationData = "", arguments = "", queue = "default"});
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+            // Arrange
+            UseConnection((connection, storage) =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new { invocationData = "", arguments = "", queue = "default" });
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				// Act
-				var payload = queue.Dequeue(
-					DefaultQueues,
-					CreateTimingOutCancellationToken());
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
 
-				// Assert
-				Assert.NotNull(payload);
+                // Assert
+                Assert.NotNull(payload);
 
-				var fetchedAt = connection.Query<DateTime?>(
-					@"select ""fetchedat"" from """ + GetSchemaName() + @""".""jobqueue"" where ""jobid"" = @id",
-					new {id = Convert.ToInt32(payload.JobId, CultureInfo.InvariantCulture)}).Single();
+                var fetchedAt = connection.Query<DateTime?>(
+                    @"select ""fetchedat"" from """ + GetSchemaName() + @""".""jobqueue"" where ""jobid"" = @id",
+                    new { id = Convert.ToInt32(payload.JobId, CultureInfo.InvariantCulture) }).Single();
 
-				Assert.NotNull(fetchedAt);
-				Assert.True(fetchedAt > DateTime.UtcNow.AddMinutes(-1));
-			});
-		}
+                Assert.NotNull(fetchedAt);
+                Assert.True(fetchedAt > DateTime.UtcNow.AddMinutes(-1));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(false);
+        }
 
-		private void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldFetchATimedOutJobs_FromTheSpecifiedQueue(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 WITH i AS (
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values (@invocationData, @arguments, now() at time zone 'utc')
@@ -252,45 +242,45 @@ select i.""id"", @queue, @fetchedAt from i;
 ";
 
 
-			// Arrange
-			UseConnection((connection, storage) =>
-			{
-				connection.Execute(
-					arrangeSql,
-					new
-					{
-						queue = "default",
-						fetchedAt = DateTime.UtcNow.AddDays(-1),
-						invocationData = "",
-						arguments = ""
-					});
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+            // Arrange
+            UseConnection((connection, storage) =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new
+                    {
+                        queue = "default",
+                        fetchedAt = DateTime.UtcNow.AddDays(-1),
+                        invocationData = "",
+                        arguments = ""
+                    });
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				// Act
-				var payload = queue.Dequeue(
-					DefaultQueues,
-					CreateTimingOutCancellationToken());
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
 
-				// Assert
-				Assert.NotEmpty(payload.JobId);
-			});
-		}
+                // Assert
+                Assert.NotEmpty(payload.JobId);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(false);
+        }
 
-		private void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldSetFetchedAt_OnlyForTheFetchedJob(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 WITH i AS (
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values (@invocationData, @arguments, now() at time zone 'utc')
@@ -299,47 +289,47 @@ insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"")
 select i.""id"", @queue from i;
 ";
 
-			UseConnection((connection, storage) =>
-			{
-				connection.Execute(
-					arrangeSql,
-					new[]
-					{
-						new {queue = "default", invocationData = "", arguments = ""},
-						new {queue = "default", invocationData = "", arguments = ""}
-					});
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+            UseConnection((connection, storage) =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new[]
+                    {
+                        new {queue = "default", invocationData = "", arguments = ""},
+                        new {queue = "default", invocationData = "", arguments = ""}
+                    });
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				// Act
-				var payload = queue.Dequeue(
-					DefaultQueues,
-					CreateTimingOutCancellationToken());
+                // Act
+                var payload = queue.Dequeue(
+                    DefaultQueues,
+                    CreateTimingOutCancellationToken());
 
-				// Assert
-				var otherJobFetchedAt = connection.Query<DateTime?>(
-					@"select ""fetchedat"" from """ + GetSchemaName() + @""".""jobqueue"" where ""jobid"" <> @id",
-					new {id = Convert.ToInt32(payload.JobId, CultureInfo.InvariantCulture)}).Single();
+                // Assert
+                var otherJobFetchedAt = connection.Query<DateTime?>(
+                    @"select ""fetchedat"" from """ + GetSchemaName() + @""".""jobqueue"" where ""jobid"" <> @id",
+                    new { id = Convert.ToInt32(payload.JobId, CultureInfo.InvariantCulture) }).Single();
 
-				Assert.Null(otherJobFetchedAt);
-			});
-		}
+                Assert.Null(otherJobFetchedAt);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(true);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(false);
-		}
+        [Fact, CleanDatabase]
+        public void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(false);
+        }
 
 
-		private void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldFetchJobs_OnlyFromSpecifiedQueues(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 WITH i AS (
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values (@invocationData, @arguments, now() at time zone 'utc')
@@ -347,36 +337,36 @@ RETURNING ""id"")
 insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"")
 select i.""id"", @queue from i;
 ";
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				connection.Execute(
-					arrangeSql,
-					new {queue = "critical", invocationData = "", arguments = ""});
+                connection.Execute(
+                    arrangeSql,
+                    new { queue = "critical", invocationData = "", arguments = "" });
 
-				Assert.Throws<OperationCanceledException>(
-					() => queue.Dequeue(
-						DefaultQueues,
-						CreateTimingOutCancellationToken()));
-			});
-		}
+                Assert.Throws<OperationCanceledException>(
+                    () => queue.Dequeue(
+                        DefaultQueues,
+                        CreateTimingOutCancellationToken()));
+            });
+        }
 
-		[Fact, CleanDatabase]
-		private void Dequeue_ShouldFetchJobs_FromMultipleQueues_WithUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchJobs_FromMultipleQueues(true);
-		}
+        [Fact, CleanDatabase]
+        private void Dequeue_ShouldFetchJobs_FromMultipleQueues_WithUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchJobs_FromMultipleQueues(true);
+        }
 
-		[Fact, CleanDatabase]
-		private void Dequeue_ShouldFetchJobs_FromMultipleQueues_WithoutUseNativeDatabaseTransactions()
-		{
-			Dequeue_ShouldFetchJobs_FromMultipleQueues(false);
-		}
+        [Fact, CleanDatabase]
+        private void Dequeue_ShouldFetchJobs_FromMultipleQueues_WithoutUseNativeDatabaseTransactions()
+        {
+            Dequeue_ShouldFetchJobs_FromMultipleQueues(false);
+        }
 
-		private void Dequeue_ShouldFetchJobs_FromMultipleQueues(bool useNativeDatabaseTransactions)
-		{
-			string arrangeSql = @"
+        private void Dequeue_ShouldFetchJobs_FromMultipleQueues(bool useNativeDatabaseTransactions)
+        {
+            string arrangeSql = @"
 WITH i AS (
 insert into """ + GetSchemaName() + @""".""job"" (""invocationdata"", ""arguments"", ""createdat"")
 values (@invocationData, @arguments, now() at time zone 'utc')
@@ -385,148 +375,146 @@ insert into """ + GetSchemaName() + @""".""jobqueue"" (""jobid"", ""queue"")
 select i.""id"", @queue from i;
 ";
 
-			var queueNames = new[] {"default", "critical"};
+            var queueNames = new[] { "default", "critical" };
 
-			UseConnection((connection, storage) =>
-			{
-				connection.Execute(
-					arrangeSql,
-					new[]
-					{
-						new {queue = queueNames.First(), invocationData = "", arguments = ""},
-						new {queue = queueNames.Last(), invocationData = "", arguments = ""}
-					});
+            UseConnection((connection, storage) =>
+            {
+                connection.Execute(
+                    arrangeSql,
+                    new[]
+                    {
+                        new {queue = queueNames.First(), invocationData = "", arguments = ""},
+                        new {queue = queueNames.Last(), invocationData = "", arguments = ""}
+                    });
 
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				var queueFirst = (PostgreSqlFetchedJob) queue.Dequeue(
-					queueNames,
-					CreateTimingOutCancellationToken());
+                var queueFirst = (PostgreSqlFetchedJob)queue.Dequeue(
+                    queueNames,
+                    CreateTimingOutCancellationToken());
 
-				Assert.NotNull(queueFirst.JobId);
-				Assert.Contains(queueFirst.Queue, queueNames);
+                Assert.NotNull(queueFirst.JobId);
+                Assert.Contains(queueFirst.Queue, queueNames);
 
-				var queueLast = (PostgreSqlFetchedJob) queue.Dequeue(
-					queueNames,
-					CreateTimingOutCancellationToken());
+                var queueLast = (PostgreSqlFetchedJob)queue.Dequeue(
+                    queueNames,
+                    CreateTimingOutCancellationToken());
 
-				Assert.NotNull(queueLast.JobId);
-				Assert.Contains(queueLast.Queue, queueNames);
-			});
-		}
+                Assert.NotNull(queueLast.JobId);
+                Assert.Contains(queueLast.Queue, queueNames);
+            });
+        }
 
-		[Fact, CleanDatabase]
-		public void Enqueue_AddsAJobToTheQueue_WithUseNativeDatabaseTransactions()
-		{
-			Enqueue_AddsAJobToTheQueue(true);
-		}
+        [Fact, CleanDatabase]
+        public void Enqueue_AddsAJobToTheQueue_WithUseNativeDatabaseTransactions()
+        {
+            Enqueue_AddsAJobToTheQueue(true);
+        }
 
-		[Fact, CleanDatabase]
-		public void Enqueue_AddsAJobToTheQueue_WithoutUseNativeDatabaseTransactions()
-		{
-			Enqueue_AddsAJobToTheQueue(false);
-		}
+        [Fact, CleanDatabase]
+        public void Enqueue_AddsAJobToTheQueue_WithoutUseNativeDatabaseTransactions()
+        {
+            Enqueue_AddsAJobToTheQueue(false);
+        }
 
-		[Fact, CleanDatabase]
-		public void Queues_Should_Support_Long_Queue_Names()
-		{
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, false);
+        [Fact, CleanDatabase]
+        public void Queues_Should_Support_Long_Queue_Names()
+        {
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, false);
 
-				var name = "very_long_name_that_is_over_20_characters_long_or_something";
+                var name = "very_long_name_that_is_over_20_characters_long_or_something";
 
-				Assert.True(name.Length > 21);
+                Assert.True(name.Length > 21);
 
-				queue.Enqueue(connection, name, "1");
+                queue.Enqueue(connection, name, "1");
 
-				var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
-				Assert.Equal(name, record.queue.ToString());
-			});
-		}
-		
-		[Fact, CleanDatabase]
-		public void Queues_Can_Dequeue_On_Signal()
-		{
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, false);
-				IFetchedJob job = null;
-				//as UseConnection does not support async-await we have to work with Thread.Sleep
+                var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
+                Assert.Equal(name, record.queue.ToString());
+            });
+        }
 
-				Task.Run(() =>
-				{
-					//dequeue the job asynchronously
-					job = queue.Dequeue(new[] {"default"}, CreateTimingOutCancellationToken());
-				});
-				//all sleeps are possibly way to high but this ensures that any race condition is unlikely
-				//to ensure that the task would run 
-				Thread.Sleep(1000);
-				Assert.Null(job);
-				//enqueue a job that does not trigger the existing queue to reevaluate its state
-				queue.Enqueue(connection, "default", "1");
-				Thread.Sleep(1000);
-				//the job should still be unset
-				Assert.Null(job);
-				//trigger a reevaluation
-				queue.FetchNextJob();
-				//wait for the Dequeue to execute and return the next job
-				Thread.Sleep(1000);
-				Assert.NotNull(job);
-			});
-		}
+        [Fact, CleanDatabase]
+        public void Queues_Can_Dequeue_On_Signal()
+        {
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, false);
+                IFetchedJob job = null;
+                //as UseConnection does not support async-await we have to work with Thread.Sleep
 
-		private void Enqueue_AddsAJobToTheQueue(bool useNativeDatabaseTransactions)
-		{
-			UseConnection((connection, storage) =>
-			{
-				var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
+                Task.Run(() =>
+                {
+                    //dequeue the job asynchronously
+                    job = queue.Dequeue(new[] { "default" }, CreateTimingOutCancellationToken());
+                });
+                //all sleeps are possibly way to high but this ensures that any race condition is unlikely
+                //to ensure that the task would run 
+                Thread.Sleep(1000);
+                Assert.Null(job);
+                //enqueue a job that does not trigger the existing queue to reevaluate its state
+                queue.Enqueue(connection, "default", "1");
+                Thread.Sleep(1000);
+                //the job should still be unset
+                Assert.Null(job);
+                //trigger a reevaluation
+                queue.FetchNextJob();
+                //wait for the Dequeue to execute and return the next job
+                Thread.Sleep(1000);
+                Assert.NotNull(job);
+            });
+        }
 
-				queue.Enqueue(connection, "default", "1");
+        private void Enqueue_AddsAJobToTheQueue(bool useNativeDatabaseTransactions)
+        {
+            UseConnection((connection, storage) =>
+            {
+                var queue = CreateJobQueue(storage, useNativeDatabaseTransactions);
 
-				var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
-				Assert.Equal("1", record.jobid.ToString());
-				Assert.Equal("default", record.queue);
-				Assert.Null(record.FetchedAt);
-			});
-		}
+                queue.Enqueue(connection, "default", "1");
 
-		private static CancellationToken CreateTimingOutCancellationToken()
-		{
-			var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-			return source.Token;
-		}
+                var record = connection.Query(@"select * from """ + GetSchemaName() + @""".""jobqueue""").Single();
+                Assert.Equal("1", record.jobid.ToString());
+                Assert.Equal("default", record.queue);
+                Assert.Null(record.FetchedAt);
+            });
+        }
+
+        private static CancellationToken CreateTimingOutCancellationToken()
+        {
+            var source = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            return source.Token;
+        }
 
 #pragma warning disable xUnit1013 // Public method should be marked as test
-		public static void Sample(string arg1, string arg2)
+        public static void Sample(string arg1, string arg2)
 #pragma warning restore xUnit1013 // Public method should be marked as test
-		{
-		}
+        {
+        }
 
-		private static PostgreSqlJobQueue CreateJobQueue(PostgreSqlStorage storage, bool useNativeDatabaseTransactions)
-		{
-			return new PostgreSqlJobQueue(storage, new PostgreSqlStorageOptions()
-			{
-				SchemaName = GetSchemaName(),
-				UseNativeDatabaseTransactions = useNativeDatabaseTransactions
-			});
-		}
+        private static PostgreSqlJobQueue CreateJobQueue(PostgreSqlStorage storage, bool useNativeDatabaseTransactions)
+        {
+            storage.Options.SchemaName = GetSchemaName();
+            storage.Options.UseNativeDatabaseTransactions = useNativeDatabaseTransactions;
+            return new PostgreSqlJobQueue(storage);
+        }
 
-		private static void UseConnection(Action<IDbConnection, PostgreSqlStorage> action)
-		{
-			var storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
+        private static void UseConnection(Action<IDbConnection, PostgreSqlStorage> action)
+        {
+            var storage = new PostgreSqlStorage(ConnectionUtils.GetConnectionString());
 
-			storage.UseConnection(connection =>
-			{
-				action(connection, storage);
-				
-				return true;
-			});
-		}
+            storage.UseConnection(null, connection =>
+            {
+                action(connection, storage);
 
-		private static string GetSchemaName()
-		{
-			return ConnectionUtils.GetSchemaName();
-		}
-	}
+                return true;
+            });
+        }
+
+        private static string GetSchemaName()
+        {
+            return ConnectionUtils.GetSchemaName();
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Dapper;
+﻿using Dapper;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
 using Moq;
 using Npgsql;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
@@ -45,8 +45,8 @@ namespace Hangfire.PostgreSql.Tests
 
             UseConnection(sql =>
             {
-                var jobId = sql.Query(arrangeSql, 
-                    new 
+                var jobId = sql.Query(arrangeSql,
+                    new
                     {
                         invocationData = SerializationHelper.Serialize(invocationData),
                         arguments = invocationData.Arguments,
@@ -83,7 +83,7 @@ namespace Hangfire.PostgreSql.Tests
             NpgsqlConnection connection,
             Action<PostgreSqlWriteOnlyTransaction> action)
         {
-            using (var transaction = new PostgreSqlWriteOnlyTransaction(connection, _options, _queueProviders))
+            using (var transaction = new PostgreSqlWriteOnlyTransaction(_storage, () => connection))
             {
                 action(transaction);
                 transaction.Commit();
@@ -91,9 +91,9 @@ namespace Hangfire.PostgreSql.Tests
         }
 
 #pragma warning disable xUnit1013 // Public method should be marked as test
-		public static void SampleMethod(string arg)
+        public static void SampleMethod(string arg)
 #pragma warning restore xUnit1013 // Public method should be marked as test
-		{
+        {
         }
     }
 }

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
@@ -4,102 +4,78 @@ using Xunit;
 
 namespace Hangfire.PostgreSql.Tests
 {
-	public class PostgreSqlStorageFacts
-	{
-		private readonly PostgreSqlStorageOptions _options;
+    public class PostgreSqlStorageFacts
+    {
+        private readonly PostgreSqlStorageOptions _options;
 
-		public PostgreSqlStorageFacts()
-		{
-			_options = new PostgreSqlStorageOptions {PrepareSchemaIfNecessary = false, EnableTransactionScopeEnlistment = true};
-		}
+        public PostgreSqlStorageFacts()
+        {
+            _options = new PostgreSqlStorageOptions { PrepareSchemaIfNecessary = false, EnableTransactionScopeEnlistment = true };
+        }
 
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlStorage(nameOrConnectionString: null));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlStorage(nameOrConnectionString: null));
 
-			Assert.Equal("nameOrConnectionString", exception.ParamName);
-		}
+            Assert.Equal("nameOrConnectionString", exception.ParamName);
+        }
 
-		[Fact]
-		public void Ctor_ThrowsAnException_WhenOptionsValueIsNull()
-		{
-			var exception = Assert.Throws<ArgumentNullException>(
-				() => new PostgreSqlStorage("hello", null));
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenOptionsValueIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new PostgreSqlStorage("hello", null));
 
-			Assert.Equal("options", exception.ParamName);
-		}
+            Assert.Equal("options", exception.ParamName);
+        }
 
-		[Fact, CleanDatabase]
-		public void Ctor_CanCreateSqlServerStorage_WithExistingConnection()
-		{
-			var connection = ConnectionUtils.CreateConnection();
-			var storage = new PostgreSqlStorage(connection, _options);
+        [Fact, CleanDatabase]
+        public void Ctor_CanCreateSqlServerStorage_WithExistingConnection()
+        {
+            var connection = ConnectionUtils.CreateConnection();
+            var storage = new PostgreSqlStorage(connection, _options);
 
-			Assert.NotNull(storage);
-		}
+            Assert.NotNull(storage);
+        }
 
-		[Fact, CleanDatabase]
-		public void Ctor_InitializesDefaultJobQueueProvider_AndPassesCorrectOptions()
-		{
-			var storage = CreateStorage();
-			var providers = storage.QueueProviders;
+        [Fact, CleanDatabase]
+        public void Ctor_InitializesDefaultJobQueueProvider_AndPassesCorrectOptions()
+        {
+            var storage = CreateStorage();
+            var providers = storage.QueueProviders;
 
-			var provider = (PostgreSqlJobQueueProvider) providers.GetProvider("default");
+            var provider = (PostgreSqlJobQueueProvider)providers.GetProvider("default");
 
-			Assert.Same(_options, provider.Options);
-		}
+            Assert.Same(_options, provider.Options);
+        }
 
-		[Fact, CleanDatabase]
-		public void GetConnection_ReturnsExistingConnection_WhenStorageUsesIt()
-		{
-			var connection = ConnectionUtils.CreateConnection();
-			var storage = new PostgreSqlStorage(connection, _options);
+        [Fact, CleanDatabase]
+        public void GetMonitoringApi_ReturnsNonNullInstance()
+        {
+            var storage = CreateStorage();
+            var api = storage.GetMonitoringApi();
+            Assert.NotNull(api);
+        }
 
-			using (var storageConnection = (PostgreSqlConnection) storage.GetConnection())
-			{
-				Assert.Same(connection, storageConnection.Connection);
-				Assert.False(storageConnection.OwnsConnection);
-			}
-		}
+        [Fact, CleanDatabase]
+        public void GetComponents_ReturnsAllNeededComponents()
+        {
+            var storage = CreateStorage();
 
-		[Fact, CleanDatabase]
-		public void GetMonitoringApi_ReturnsNonNullInstance()
-		{
-			var storage = CreateStorage();
-			var api = storage.GetMonitoringApi();
-			Assert.NotNull(api);
-		}
+            var components = storage.GetComponents();
 
-		[Fact, CleanDatabase]
-		public void GetConnection_ReturnsNonNullInstance()
-		{
-			var storage = CreateStorage();
-			using (var connection = (PostgreSqlConnection) storage.GetConnection())
-			{
-				Assert.NotNull(connection);
-				Assert.True(connection.OwnsConnection);
-			}
-		}
+            var componentTypes = components.Select(x => x.GetType()).ToArray();
+            Assert.Contains(typeof(ExpirationManager), componentTypes);
+        }
 
-		[Fact, CleanDatabase]
-		public void GetComponents_ReturnsAllNeededComponents()
-		{
-			var storage = CreateStorage();
-
-			var components = storage.GetComponents();
-
-			var componentTypes = components.Select(x => x.GetType()).ToArray();
-			Assert.Contains(typeof(ExpirationManager), componentTypes);
-		}
-
-		private PostgreSqlStorage CreateStorage()
-		{
-			return new PostgreSqlStorage(
-				ConnectionUtils.GetConnectionString(),
-				_options);
-		}
-	}
+        private PostgreSqlStorage CreateStorage()
+        {
+            return new PostgreSqlStorage(
+                ConnectionUtils.GetConnectionString(),
+                _options);
+        }
+    }
 }

--- a/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageExtensions.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Hangfire.PostgreSql.Tests
+{
+    internal static class PostgreSqlStorageExtensions
+    {
+        public static PostgreSqlConnection GetStorageConnection(this PostgreSqlStorage storage) =>
+            storage.GetConnection() as PostgreSqlConnection;
+    }
+}

--- a/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageFixture.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageFixture.cs
@@ -1,34 +1,83 @@
-﻿using Npgsql;
+﻿using Moq;
+using Npgsql;
 using System;
 
 namespace Hangfire.PostgreSql.Tests
 {
     public class PostgreSqlStorageFixture : IDisposable
     {
+        private readonly Mock<IPersistentJobQueue> _queueMock;
+        private readonly PersistentJobQueueProviderCollection _providers;
+        private readonly PostgreSqlStorageOptions _storageOptions;
+        private NpgsqlConnection _mainConnection;
         private bool _initialized;
+
+        public PostgreSqlStorageFixture()
+        {
+            _queueMock = new Mock<IPersistentJobQueue>();
+
+            var provider = new Mock<IPersistentJobQueueProvider>();
+            provider.Setup(x => x.GetJobQueue())
+                .Returns(_queueMock.Object);
+
+            _providers = new PersistentJobQueueProviderCollection(provider.Object);
+
+            _storageOptions = new PostgreSqlStorageOptions
+            {
+                SchemaName = ConnectionUtils.GetSchemaName(),
+                EnableTransactionScopeEnlistment = true
+            };
+        }
+
+        public void Dispose()
+        {
+            _mainConnection?.Dispose();
+            _mainConnection = null;
+        }
+
+        public Mock<IPersistentJobQueue> PersistentJobQueueMock => _queueMock;
+        public PersistentJobQueueProviderCollection PersistentJobQueueProviderCollection => _providers;
+        public PostgreSqlStorage Storage { get; private set; }
+        public NpgsqlConnection MainConnection => _mainConnection ?? (_mainConnection = ConnectionUtils.CreateConnection());
+
+        public void SetupOptions(Action<PostgreSqlStorageOptions> storageOptionsConfigure) =>
+            storageOptionsConfigure(_storageOptions);
+
+        public PostgreSqlStorage SafeInit(NpgsqlConnection connection = null)
+        {
+            return _initialized
+                ? Storage
+                : ForceInit(connection);
+        }
+
+        public PostgreSqlStorage ForceInit(NpgsqlConnection connection = null)
+        {
+            Storage = new PostgreSqlStorage(connection ?? MainConnection, _storageOptions)
+            {
+                QueueProviders = _providers
+            };
+            _initialized = true;
+            return Storage;
+        }
 
         public void SafeInit(PostgreSqlStorageOptions options, PersistentJobQueueProviderCollection jobQueueProviderCollection = null, NpgsqlConnection connection = null)
         {
-            if (_initialized)
+            if (!_initialized)
             {
+                ForceInit(options, jobQueueProviderCollection, connection);
                 return;
             }
 
-            ForceInit(options, jobQueueProviderCollection, connection);
+            Storage.QueueProviders = jobQueueProviderCollection;
         }
 
         public void ForceInit(PostgreSqlStorageOptions options, PersistentJobQueueProviderCollection jobQueueProviderCollection = null, NpgsqlConnection connection = null)
         {
-            Storage = new PostgreSqlStorage(connection ?? ConnectionUtils.CreateConnection(), options);
-            if (jobQueueProviderCollection != null)
+            Storage = new PostgreSqlStorage(connection ?? MainConnection, options)
             {
-                Storage.QueueProviders = jobQueueProviderCollection;
-            }
+                QueueProviders = jobQueueProviderCollection
+            };
             _initialized = true;
         }
-
-        public PostgreSqlStorage Storage { get; private set; }
-
-        public void Dispose() { }
     }
 }

--- a/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageFixture.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/PostgreSqlStorageFixture.cs
@@ -1,0 +1,34 @@
+﻿using Npgsql;
+using System;
+
+namespace Hangfire.PostgreSql.Tests
+{
+    public class PostgreSqlStorageFixture : IDisposable
+    {
+        private bool _initialized;
+
+        public void SafeInit(PostgreSqlStorageOptions options, PersistentJobQueueProviderCollection jobQueueProviderCollection = null, NpgsqlConnection connection = null)
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            ForceInit(options, jobQueueProviderCollection, connection);
+        }
+
+        public void ForceInit(PostgreSqlStorageOptions options, PersistentJobQueueProviderCollection jobQueueProviderCollection = null, NpgsqlConnection connection = null)
+        {
+            Storage = new PostgreSqlStorage(connection ?? ConnectionUtils.CreateConnection(), options);
+            if (jobQueueProviderCollection != null)
+            {
+                Storage.QueueProviders = jobQueueProviderCollection;
+            }
+            _initialized = true;
+        }
+
+        public PostgreSqlStorage Storage { get; private set; }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Many times we've been hit by the pool exhaustion exceptions when running the hangfire instance using this provider. Changes in this PR are somewhat copied over from Hangfire.SqlServer provider. Idea is to use one connection for a single resource.

We've been running this DLL for 4 months now and haven't experienced another exception related to connection pool since then.