### PR TITLE
Bring back support for Npgsql 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ app.UseHangfireDashboard();
 ```
 
 ### For ASP.NET Core
-First, additional NuGet packages needs installation: 
-* Hangfire
-* Hangfire.AspNetCore
-* Hangfire.PostgreSql
+First, NuGet package needs installation.
+* Hangfire.PostgreSql (Uses Npgsql 6)
+* Hangfire.PostgreSql.Npgsql5 (Uses Npgsql 5)
 
+Both packages are functionally the same, the only difference is the underlying Npgsql dependency version.
 
 In `Startup.cs` _ConfigureServices(IServiceCollection services)_ method add the following line:
 ```csharp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ build_script:
     createdb hangfire_tests
 
     .\build.ps1 -t Pack
+    .\build.ps1 -t Pack -NpgsqlVersion 5
 cache:
 - tools -> build.cake
 - tools -> build.ps1

--- a/build.cake
+++ b/build.cake
@@ -36,7 +36,6 @@ Task("Build")
 {
     var settings = new DotNetCoreBuildSettings
     {
-        
         ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}"),
         Configuration = "Release",
         NoRestore = true

--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,7 @@ IEnumerable<string> GetFrameworks(string path)
 Task("Restore")
   .Does(() =>
 {
-    var settings= new DotNetCoreRestoreSettings
+    var settings = new DotNetCoreRestoreSettings
     {
         ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}")
     };
@@ -64,10 +64,14 @@ Task("Test")
   .Does(() =>
 {
     var files = GetFiles("tests/**/*.csproj");
+    var settings = new DotNetCoreTestSettings
+    {
+        ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}")
+    };
     foreach(var file in files)
     {
         Information("Testing: {0}", file);
-        DotNetCoreTest(file.ToString());
+        DotNetCoreTest(file.ToString(), settings);
     }
 });
 

--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,11 @@
-#addin nuget:?package=Newtonsoft.Json&version=9.0.1
+﻿#addin nuget:?package=Newtonsoft.Json&version=9.0.1
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
 
 var target = Argument("target", "Default");
+var npgsqlVersion = Argument("npgsql", "Default");
 
 //////////////////////////////////////////////////////////////////////
 // FUNCTIONS
@@ -22,7 +23,11 @@ IEnumerable<string> GetFrameworks(string path)
 Task("Restore")
   .Does(() =>
 {
-    DotNetCoreRestore();
+    var settings= new DotNetCoreRestoreSettings
+    {
+        ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}")
+    };
+    DotNetCoreRestore(settings);
 });
 
 Task("Build")
@@ -31,7 +36,10 @@ Task("Build")
 {
     var settings = new DotNetCoreBuildSettings
     {
-        Configuration = "Release"
+        
+        ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}"),
+        Configuration = "Release",
+        NoRestore = true
     };
 
     var projects = GetFiles("./src/**/*.csproj");
@@ -70,6 +78,7 @@ Task("Pack")
 {
     var settings = new DotNetCorePackSettings
     {
+        ArgumentCustomization = args => args.Append($"-p:NpgsqlVersion={npgsqlVersion}"),
         Configuration = "Release",
         OutputDirectory = "publish/",
         NoBuild = true

--- a/build.ps1
+++ b/build.ps1
@@ -40,15 +40,19 @@ Param(
     [string]$Script,
     [string]$Target,
     [string]$Configuration,
+    [Parameter(Mandatory=$false)]
+    [string]$NpgsqlVersion,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
     [string]$Verbosity,
     [switch]$ShowDescription,
     [Alias("WhatIf", "Noop")]
     [switch]$DryRun,
     [switch]$SkipToolPackageRestore,
-    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [Parameter(Position=0, Mandatory=$false, ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
+
+if (!$NpgsqlVersion) { $NpgsqlVersion = 'Default'; }
 
 # This is an automatic variable in PowerShell Core, but not in Windows PowerShell 5.x
 if (-not (Test-Path variable:global:IsCoreCLR)) {
@@ -90,12 +94,12 @@ function MD5HashFile([string] $filePath)
     }
     finally
     {
-        if ($file -ne $null)
+        if ($null -ne $file)
         {
             $file.Dispose()
         }
         
-        if ($md5 -ne $null)
+        if ($null -ne $md5)
         {
             $md5.Dispose()
         }
@@ -156,8 +160,8 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Trying to find nuget.exe in PATH..."
     $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
-    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
-    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
+    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select-Object -First 1
+    if ($null -ne $NUGET_EXE_IN_PATH -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
         Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
         $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
     }
@@ -271,6 +275,7 @@ if ($Configuration) { $cakeArguments += "--configuration=$Configuration" }
 if ($Verbosity) { $cakeArguments += "--verbosity=$Verbosity" }
 if ($ShowDescription) { $cakeArguments += "--showdescription" }
 if ($DryRun) { $cakeArguments += "--dryrun" }
+$cakeArguments += "--npgsql=${NpgsqlVersion}"
 $cakeArguments += $ScriptArgs
 
 # Start Cake

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Description>PostgreSql storage implementation for Hangfire (background job system for ASP.NET and aspnet core applications).</Description>
     <Copyright>Copyright © 2014-2021 Frank Hommers and others</Copyright>
     <AssemblyTitle>Hangfire PostgreSql Storage</AssemblyTitle>
-    <VersionPrefix>1.8.6</VersionPrefix>
+    <VersionPrefix>1.9.4</VersionPrefix>
     <Authors>Frank Hommers and others (Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Vytautas Kasparavičius (vytautask), Vincent Vrijburg, David Roth (davidroth).</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Hangfire.PostgreSql</AssemblyName>
@@ -13,9 +13,9 @@
     <PackageReleaseNotes>https://github.com/frankhommers/Hangfire.PostgreSql/releases</PackageReleaseNotes>
     <PackageProjectUrl>http://hmm.rs/Hangfire.PostgreSql</PackageProjectUrl>
     <PackageLicenseUrl></PackageLicenseUrl>
-    <Version>1.8.6.0</Version>
-    <FileVersion>1.8.6.0</FileVersion>
-    <AssemblyVersion>1.8.6.0</AssemblyVersion>
+    <Version>1.9.4.0</Version>
+    <FileVersion>1.9.4.0</FileVersion>
+    <AssemblyVersion>1.9.4.0</AssemblyVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <RepositoryUrl>https://github.com/frankhommers/Hangfire.PostgreSql</RepositoryUrl>

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -9,7 +9,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Hangfire.PostgreSql</AssemblyName>
     <OutputType>Library</OutputType>
-    <PackageId>Hangfire.PostgreSql</PackageId>
     <PackageTags>Hangfire;PostgreSql;Postgres</PackageTags>
     <PackageReleaseNotes>https://github.com/frankhommers/Hangfire.PostgreSql/releases</PackageReleaseNotes>
     <PackageProjectUrl>http://hmm.rs/Hangfire.PostgreSql</PackageProjectUrl>
@@ -37,7 +36,6 @@
     </PackageReference>
     <PackageReference Include="Hangfire.Core" Version="1.7.27" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Npgsql" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,5 +44,28 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+  
+  <!-- Overrides for Cake script -->
+
+  <Choose>
+    <When Condition="'$(NpgsqlVersion)' == '5'">
+      <PropertyGroup>
+        <PackageId>Hangfire.PostgreSql.Npgsql5</PackageId>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Npgsql" Version="5.0.0" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <PackageId>Hangfire.PostgreSql</PackageId>
+      </PropertyGroup>
+      <ItemGroup>
+        <PackageReference Include="Npgsql" Version="6.0.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <!-- END Overrides for Cake script -->
 
 </Project>


### PR DESCRIPTION
Fixes #222.

Multiple packages will be published to NuGet after these changes, first one as usual, the second (named Hangfire.PostgreSql.Npgsql5) will contain reference to Npgsql5+ instead of 6+.