### PR TITLE
Fixed exception when enqueuing a job within an existing transaction scope

### DIFF
--- a/src/Hangfire.PostgreSql/EnvironmentHelpers.cs
+++ b/src/Hangfire.PostgreSql/EnvironmentHelpers.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hangfire.PostgreSql
+{
+  internal class EnvironmentHelpers
+  {
+    private static bool? _isMono;
+
+    public static bool IsMono() =>
+      _isMono ??= Type.GetType("Mono.Runtime") != null;
+  }
+}

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -237,7 +237,7 @@ namespace Hangfire.PostgreSql
     {
       isolationLevel = isolationLevel ?? IsolationLevel.ReadCommitted;
 
-      if (IsRunningOnWindows() || Options.EnableTransactionScopeEnlistment)
+      if (!IsRunningOnMono())
       {
         using (TransactionScope transaction = CreateTransaction(isolationLevel))
         {
@@ -319,13 +319,10 @@ namespace Hangfire.PostgreSql
       }
     }
 
-    private static bool IsRunningOnWindows()
+    private static bool? _isRunningOnMono;
+    private static bool IsRunningOnMono()
     {
-#if !NETSTANDARD1_3
-      return Environment.OSVersion.Platform == PlatformID.Win32NT;
-#else
-            return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
-#endif
+      return _isRunningOnMono ??= Type.GetType("Mono.Runtime") != null;
     }
 
     private static TransactionScope CreateTransaction(IsolationLevel? isolationLevel)

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -237,7 +237,7 @@ namespace Hangfire.PostgreSql
     {
       isolationLevel = isolationLevel ?? IsolationLevel.ReadCommitted;
 
-      if (!IsRunningOnMono())
+      if (!EnvironmentHelpers.IsMono())
       {
         using (TransactionScope transaction = CreateTransaction(isolationLevel))
         {
@@ -317,12 +317,6 @@ namespace Hangfire.PostgreSql
       {
         PostgreSqlJobQueue._newItemInQueueEvent.Set();
       }
-    }
-
-    private static bool? _isRunningOnMono;
-    private static bool IsRunningOnMono()
-    {
-      return _isRunningOnMono ??= Type.GetType("Mono.Runtime") != null;
     }
 
     private static TransactionScope CreateTransaction(IsolationLevel? isolationLevel)

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -1,4 +1,4 @@
-// This file is part of Hangfire.PostgreSql.
+﻿// This file is part of Hangfire.PostgreSql.
 // Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
 // 
 // Hangfire.PostgreSql is free software: you can redistribute it and/or modify
@@ -237,7 +237,7 @@ namespace Hangfire.PostgreSql
     {
       isolationLevel = isolationLevel ?? IsolationLevel.ReadCommitted;
 
-      if (IsRunningOnWindows())
+      if (IsRunningOnWindows() || Options.EnableTransactionScopeEnlistment)
       {
         using (TransactionScope transaction = CreateTransaction(isolationLevel))
         {


### PR DESCRIPTION
Fixes #225 

As noted in the issue, this exception only appeared on Linux.

An existing unit test for the transaction enlistment actually failed when ran within Linux (dotnet-sdk). This test now succeeds. `Hangfire.PostgreSql.Tests.PostgreSqlConnectionFacts.CreateExpiredJob_EnlistsInTransaction`.

Another test currently fails on my machine, but it did that also without any of my changes. So I guess it's not affected by this MR (`SetRangeInHash_DoesNotThrowSerializationException` with timeouts).

Possible breaking changes:  
I guess nothing, as the transaction scope enlistment has to be explicitly activated and then it behaves as expected.

How to test:  
If you happen not to have Linux at hand, but have Docker running, you can simply test it with the following line:
```
docker run -v "Your_Source_Directory_FullPath_Here":/src --rm mcr.microsoft.com/dotnet/sdk:6.0 dotnet test -l 'console;verbosity=detailed' /src
```
But you probably need to set the host of `ConnectionUtils.DefaultConnectionStringTemplate` to `host.docker.internal`.