### PR TITLE
Change timestamp columns to timestamptz to support Npgsql 6

### DIFF
--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -87,7 +87,7 @@ namespace Hangfire.PostgreSql
                 WHERE ""id"" IN (
                     SELECT ""id"" 
                     FROM ""{_storage.Options.SchemaName}"".""{table}"" 
-                    WHERE ""expireat"" < NOW() AT TIME ZONE 'UTC' 
+                    WHERE ""expireat"" < NOW() 
                     LIMIT {_storage.Options.DeleteExpiredBatchSize.ToString(CultureInfo.InvariantCulture)}
                 )", transaction: transaction);
 

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -364,7 +364,7 @@ namespace Hangfire.PostgreSql
 
       string sql = $@"
         WITH ""inputvalues"" AS (
-	        SELECT @Id ""id"", @Data ""data"", NOW() AT TIME ZONE 'UTC' ""lastheartbeat""
+	        SELECT @Id ""id"", @Data ""data"", NOW() ""lastheartbeat""
         ), ""updatedrows"" AS ( 
 	        UPDATE ""{_options.SchemaName}"".""server"" ""updatetarget""
 	        SET ""data"" = ""inputvalues"".""data"", ""lastheartbeat"" = ""inputvalues"".""lastheartbeat""
@@ -400,7 +400,7 @@ namespace Hangfire.PostgreSql
 
       string query = $@"
         UPDATE ""{_options.SchemaName}"".""server"" 
-				SET ""lastheartbeat"" = NOW() AT TIME ZONE 'UTC' 
+				SET ""lastheartbeat"" = NOW() 
 				WHERE ""id"" = @Id;
       ";
 
@@ -422,7 +422,7 @@ namespace Hangfire.PostgreSql
 
       string query = $@"
         DELETE FROM ""{_options.SchemaName}"".""server"" 
-				WHERE ""lastheartbeat"" < (NOW() AT TIME ZONE 'UTC' - INTERVAL '{((long)timeOut.TotalMilliseconds).ToString(CultureInfo.InvariantCulture)} MILLISECONDS');";
+				WHERE ""lastheartbeat"" < (NOW() - INTERVAL '{((long)timeOut.TotalMilliseconds).ToString(CultureInfo.InvariantCulture)} MILLISECONDS');";
 
       return _storage.UseConnection(_dedicatedConnection, connection => connection.Execute(query));
     }

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -84,7 +84,7 @@ namespace Hangfire.PostgreSql
 
       string fetchJobSqlTemplate = $@"
         UPDATE ""{_storage.Options.SchemaName}"".""jobqueue"" 
-        SET ""fetchedat"" = NOW() AT TIME ZONE 'UTC'
+        SET ""fetchedat"" = NOW()
         WHERE ""id"" = (
           SELECT ""id"" 
           FROM ""{_storage.Options.SchemaName}"".""jobqueue"" 
@@ -99,7 +99,7 @@ namespace Hangfire.PostgreSql
 
       string[] fetchConditions = {
         "IS NULL",
-        $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'",
+        $"< NOW() + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'",
       };
       
       int fetchConditionsIndex = 0;
@@ -184,7 +184,7 @@ namespace Hangfire.PostgreSql
 
       string markJobAsFetchedSql = $@"
         UPDATE ""{_storage.Options.SchemaName}"".""jobqueue"" 
-        SET ""fetchedat"" = NOW() AT TIME ZONE 'UTC', 
+        SET ""fetchedat"" = NOW(), 
             ""updatecount"" = (""updatecount"" + 1) % 2000000000
         WHERE ""id"" = @Id 
         AND ""updatecount"" = @UpdateCount
@@ -193,7 +193,7 @@ namespace Hangfire.PostgreSql
 
       string[] fetchConditions = {
         "IS NULL",
-        $"< NOW() AT TIME ZONE 'UTC' + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'",
+        $"< NOW() + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS'",
       };
 
       int fetchConditionsIndex = 0;

--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -85,7 +85,7 @@ namespace Hangfire.PostgreSql
     {
       string sql = $@"
         UPDATE ""{_storage.Options.SchemaName}"".""job""
-        SET ""expireat"" = NOW() AT TIME ZONE 'UTC' + INTERVAL '{(long)expireIn.TotalSeconds} SECONDS'
+        SET ""expireat"" = NOW() + INTERVAL '{(long)expireIn.TotalSeconds} SECONDS'
         WHERE ""id"" = @Id;
       ";
 
@@ -168,7 +168,7 @@ namespace Hangfire.PostgreSql
     {
       string sql = $@"
         INSERT INTO ""{_storage.Options.SchemaName}"".""counter""(""key"", ""value"", ""expireat"") 
-        VALUES (@Key, @Value, NOW() AT TIME ZONE 'UTC' + INTERVAL '{(long)expireIn.TotalSeconds} SECONDS');
+        VALUES (@Key, @Value, NOW() + INTERVAL '{(long)expireIn.TotalSeconds} SECONDS');
       ";
       QueueCommand(con => con.Execute(sql,
         new { Key = key, Value = +1 }));
@@ -188,7 +188,7 @@ namespace Hangfire.PostgreSql
     {
       string sql = $@"
         INSERT INTO ""{_storage.Options.SchemaName}"".""counter""(""key"", ""value"", ""expireat"") 
-        VALUES (@Key, @Value, NOW() AT TIME ZONE 'UTC' + INTERVAL '{((long)expireIn.TotalSeconds).ToString(CultureInfo.InvariantCulture)} SECONDS');
+        VALUES (@Key, @Value, NOW() + INTERVAL '{((long)expireIn.TotalSeconds).ToString(CultureInfo.InvariantCulture)} SECONDS');
       ";
       QueueCommand(con => con.Execute(sql, new { Key = key, Value = -1 }));
     }

--- a/src/Hangfire.PostgreSql/Scripts/Install.v16.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v16.sql
@@ -1,0 +1,23 @@
+﻿SET search_path = 'hangfire';
+
+DO
+$$
+    BEGIN
+        IF EXISTS(SELECT 1 FROM "schema" WHERE "version"::integer >= 16) THEN
+            RAISE EXCEPTION 'version-already-applied';
+        END IF;
+    END
+$$;
+
+ALTER TABLE counter ALTER COLUMN expireat TYPE timestamptz;
+ALTER TABLE hash ALTER COLUMN expireat TYPE timestamptz;
+ALTER TABLE job ALTER COLUMN createdat TYPE timestamptz;
+ALTER TABLE job ALTER COLUMN expireat TYPE timestamptz;
+ALTER TABLE jobqueue ALTER COLUMN fetchedat TYPE timestamptz;
+ALTER TABLE list ALTER COLUMN expireat TYPE timestamptz;
+ALTER TABLE lock ALTER COLUMN acquired TYPE timestamptz;
+ALTER TABLE server ALTER COLUMN lastheartbeat TYPE timestamptz;
+ALTER TABLE "set" ALTER COLUMN expireat TYPE timestamptz;
+ALTER TABLE state ALTER COLUMN createdat TYPE timestamptz;
+
+RESET search_path;

--- a/tests/Hangfire.PostgreSql.Tests/ExpirationManagerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/ExpirationManagerFacts.cs
@@ -125,7 +125,7 @@ namespace Hangfire.PostgreSql.Tests
         // Arrange
         string createSql = $@"
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"", ""expireat"") 
-          VALUES ('', '', NOW() AT TIME ZONE 'UTC', @ExpireAt)
+          VALUES ('', '', NOW(), @ExpireAt)
         ";
         connection.Execute(createSql, new { ExpireAt = DateTime.UtcNow.AddMonths(-1) });
 
@@ -199,7 +199,7 @@ namespace Hangfire.PostgreSql.Tests
 
       string insertSqlValue = $@"
         INSERT INTO ""{GetSchemaName()}"".""counter""(""key"", ""value"", ""expireat"")
-        VALUES (@Key, 1, NOW() AT TIME ZONE 'UTC' - interval '{{0}} seconds') RETURNING ""id""
+        VALUES (@Key, 1, NOW() - interval '{{0}} seconds') RETURNING ""id""
       ";
 
       string insertSql = expireAt == null

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
@@ -191,7 +191,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
-        VALUES (@InvocationData, @Arguments, @StateName, NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES (@InvocationData, @Arguments, @StateName, NOW()) RETURNING ""id""
       ";
 
       UseConnections((connection, jobStorageConnection) => {
@@ -239,15 +239,15 @@ namespace Hangfire.PostgreSql.Tests
     {
       string createJobSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
-        VALUES ('', '', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id"";
+        VALUES ('', '', '', NOW()) RETURNING ""id"";
       ";
 
       string createStateSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""state"" (""jobid"", ""name"", ""createdat"")
-        VALUES(@JobId, 'old-state', NOW() AT TIME ZONE 'UTC');
+        VALUES(@JobId, 'old-state', NOW());
 
         INSERT INTO ""{GetSchemaName()}"".""state"" (""jobid"", ""name"", ""reason"", ""data"", ""createdat"")
-        VALUES(@JobId, @Name, @Reason, @Data, NOW() AT TIME ZONE 'UTC')
+        VALUES(@JobId, @Name, @Reason, @Data, NOW())
         RETURNING ""id"";
       ";
 
@@ -284,7 +284,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""statename"", ""createdat"")
-        VALUES (@InvocationData, @Arguments, @StateName, NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES (@InvocationData, @Arguments, @StateName, NOW()) RETURNING ""id""
       ";
 
       UseConnections((connection, jobStorageConnection) => {
@@ -329,7 +329,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES ('', '', NOW()) RETURNING ""id""
       ";
 
       UseConnections((connection, jobStorageConnection) => {
@@ -350,7 +350,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES ('', '', NOW()) RETURNING ""id""
       ";
 
       UseConnections((connection, jobStorageConnection) => {
@@ -372,7 +372,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES ('', '', NOW()) RETURNING ""id""
       ";
 
       UseConnections((connection, jobStorageConnection) => {
@@ -426,7 +426,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH ""insertedjob"" AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+          VALUES ('', '', NOW()) RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobparameter"" (""jobid"", ""name"", ""value"")
         SELECT ""insertedjob"".""id"", @Name, @Value
@@ -557,8 +557,8 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""server"" (""id"", ""data"", ""lastheartbeat"")
-        VALUES ('Server1', '', NOW() AT TIME ZONE 'UTC'),
-        ('Server2', '', NOW() AT TIME ZONE 'UTC')
+        VALUES ('Server1', '', NOW()),
+        ('Server2', '', NOW())
       ";
 
       UseConnections((connection, jobStorageConnection) => {

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlConnectionFacts.cs
@@ -133,7 +133,7 @@ namespace Hangfire.PostgreSql.Tests
     public void CreateExpiredJob_CreatesAJobInTheStorage_AndSetsItsParameters()
     {
       UseConnections((connection, jobStorageConnection) => {
-        DateTime createdAt = new DateTime(2012, 12, 12);
+        DateTime createdAt = new DateTime(2012, 12, 12, 0, 0, 0, DateTimeKind.Utc);
         string jobId = jobStorageConnection.CreateExpiredJob(Job.FromExpression(() => SampleMethod("Hello")),
           new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
           createdAt,
@@ -1241,7 +1241,7 @@ namespace Hangfire.PostgreSql.Tests
       }
 
       string jobId = null;
-      DateTime createdAt = new DateTime(2012, 12, 12);
+      DateTime createdAt = new DateTime(2012, 12, 12, 0, 0, 0, DateTimeKind.Utc);
       using (TransactionScope scope = CreateTransactionScope())
       {
         UseConnections((_, connection) => {

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
@@ -128,7 +128,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"", ""fetchedat"")
-        VALUES (@Id, @Queue, NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES (@Id, @Queue, NOW()) RETURNING ""id""
       ";
 
       return

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
@@ -19,7 +19,7 @@ namespace Hangfire.PostgreSql.Tests
           PostgreSqlObjectsInstaller.Install(connection, schemaName);
 
           int lastVersion = connection.Query<int>($@"SELECT version FROM ""{schemaName}"".""schema""").Single();
-          Assert.Equal(15, lastVersion);
+          Assert.Equal(16, lastVersion);
 
           connection.Execute($@"DROP SCHEMA ""{schemaName}"" CASCADE;");
         });
@@ -38,7 +38,7 @@ namespace Hangfire.PostgreSql.Tests
           PostgreSqlObjectsInstaller.Install(connection, schemaName);
 
           int lastVersion = connection.Query<int>($@"SELECT version FROM ""{schemaName}"".""schema""").Single();
-          Assert.Equal(15, lastVersion);
+          Assert.Equal(16, lastVersion);
 
           connection.Execute($@"DROP SCHEMA ""{schemaName}"" CASCADE;");
         });

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -193,7 +193,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH i AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC')
+          VALUES (@InvocationData, @Arguments, NOW())
           RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"")
@@ -240,7 +240,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH i AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC')
+          VALUES (@InvocationData, @Arguments, NOW())
           RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"", ""fetchedat"")
@@ -287,7 +287,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH i AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC')
+          VALUES (@InvocationData, @Arguments, NOW())
           RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"")
@@ -334,7 +334,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH i AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC')
+          VALUES (@InvocationData, @Arguments, NOW())
           RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"")
@@ -370,7 +370,7 @@ namespace Hangfire.PostgreSql.Tests
       string arrangeSql = $@"
         WITH i AS (
           INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-          VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC')
+          VALUES (@InvocationData, @Arguments, NOW())
           RETURNING ""id""
         )
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"")

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlMonitoringApiFacts.cs
@@ -29,7 +29,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{ConnectionUtils.GetSchemaName()}"".""job""(""invocationdata"", ""arguments"", ""createdat"")
-        VALUES (@InvocationData, @Arguments, NOW() AT TIME ZONE 'UTC') RETURNING ""id""";
+        VALUES (@InvocationData, @Arguments, NOW()) RETURNING ""id""";
 
       Job job = Job.FromExpression(() => SampleMethod("Hello"));
       InvocationData invocationData = InvocationData.SerializeJob(job);

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlWriteOnlyTransactionFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlWriteOnlyTransactionFacts.cs
@@ -75,7 +75,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"", ""expireat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC', NOW() AT TIME ZONE 'UTC') RETURNING ""id""
+        VALUES ('', '', NOW(), NOW()) RETURNING ""id""
       ";
 
       UseConnection(connection => {
@@ -98,7 +98,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""";
+        VALUES ('', '', NOW()) RETURNING ""id""";
 
       UseConnection(connection => {
         dynamic jobId = connection.Query(arrangeSql).Single().id.ToString();
@@ -148,7 +148,7 @@ namespace Hangfire.PostgreSql.Tests
 
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC') RETURNING ""id""";
+        VALUES ('', '', NOW()) RETURNING ""id""";
 
 
       string jobId = null;
@@ -209,7 +209,7 @@ namespace Hangfire.PostgreSql.Tests
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""job"" (""invocationdata"", ""arguments"", ""createdat"")
-        VALUES ('', '', NOW() AT TIME ZONE 'UTC')
+        VALUES ('', '', NOW())
         RETURNING ""id""
       ";
 


### PR DESCRIPTION
This is a draft PR to discuss and prototype changes to address https://github.com/frankhommers/Hangfire.PostgreSql/issues/221

See comment https://github.com/frankhommers/Hangfire.PostgreSql/issues/221#issuecomment-1001277778 for more information.

## Test run note ##
This PR includes a new schema migration to change the column types for `timestamp` to `timestamptz` which will affect other branch test runs, you may want to `drop table hangfire_tests` after switching away from this branch so the test schema is re-built with the old column type for other branches.