### PR TITLE
Change AppVeyor database timezone to non-UTC to surface DateTime conversion issues under test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,12 @@ image: Visual Studio 2022
 platform: Any CPU
 init:
 - ps: >-
+    # Change default database session timezone from UTC to catch potential DateTime/timestamp
+    # column conversion issues during unit test runs under CI
+    # See https://github.com/frankhommers/Hangfire.PostgreSql/issues/221#issuecomment-1001277778
+
+    Add-Content "c:\program files\postgresql\9.6\data\postgresql.conf" "timezone = 'UTC+13'"
+
     Set-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             ::1/128            trust"
 
     Add-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             127.0.0.1/32            trust"
@@ -12,6 +18,8 @@ services: postgresql
 build_script:
 - ps: >-
     psql -U postgres -c "CREATE ROLE appveyor LOGIN SUPERUSER CREATEDB CREATEROLE;"
+
+    psql -U postgres -c "SHOW TIME ZONE;"
 
     createdb hangfire_tests
 


### PR DESCRIPTION
See https://github.com/frankhommers/Hangfire.PostgreSql/issues/221#issuecomment-1001277778

This PR changes the appveyor CI's test database timezone to be non-UTC, to expose unit test failures due to DateTime timezone conversion issues under Npgsql 6.

__Note__ Unfortunately appveyor is hiding the test failures in the Tests tab, if you see the Console output though you will see failures. This is because the unit tests are run twice (once for Npgsql 6, then 5) so they initially fail but are overridden to pass when the npgql 5 configuration is ran.

I tried duplicating the test results with separate test config files but appveyor did not show the tests twice as desired, ideally we could fix that too to show the combined test results.