### PR TITLE
Use 'matrix builds' with AppVeyor CI to run Npgsql 5 and 6 builds separately

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 ﻿version: '0.0.0.{build}'
 image: Visual Studio 2022
 platform: Any CPU
+
+environment:
+  matrix:
+    - BUILD_NPGSQL_VERSION: 5
+    - BUILD_NPGSQL_VERSION: 6
+
 init:
 - ps: >-
     Set-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             ::1/128            trust"
@@ -15,9 +21,7 @@ build_script:
 
     createdb hangfire_tests
 
-    .\build.ps1 -t Pack
-
-    .\build.ps1 -t Pack -NpgsqlVersion 5
+    .\build.ps1 -t Pack -NpgsqlVersion $env:BUILD_NPGSQL_VERSION
 cache:
 - tools -> build.cake
 - tools -> build.ps1


### PR DESCRIPTION
This allows both builds to be tested separately, instead of one build's test results overwriting the previous builds results, see https://ci.appveyor.com/project/AndrewA/hangfire-postgresql/builds/42029011 for an example. Note that nupkg artifacts are now separated.

This helps reveal the test failures in CI that occur under Npgsql v6 with a non-UTC time zone set, see #232

Note that the version 5 and 6 values used for `BUILD_NPGSQL_VERSION` env var is only parsed to be `5` or anything else (to mean `6`) as per https://github.com/frankhommers/Hangfire.PostgreSql/pull/224/files#diff-7058d51fab2cfa0f0ff04d78a112d95507be445c0f9c1a38bb0a780513482f4bR50-R67

See https://www.appveyor.com/docs/build-configuration/#build-matrix