### PR TITLE
Always use UTC timezone for connection to ensure Npgsql 6 compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,12 @@ image: Visual Studio 2022
 platform: Any CPU
 init:
 - ps: >-
+    # Change default database session timezone from UTC to catch potential DateTime/timestamp
+    # column conversion issues during unit test runs under CI
+    # See https://github.com/frankhommers/Hangfire.PostgreSql/issues/221#issuecomment-1001277778
+
+    Add-Content "c:\program files\postgresql\9.6\data\postgresql.conf" "timezone = 'UTC+13'"
+
     Set-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             ::1/128            trust"
 
     Add-Content "c:\program files\postgresql\9.6\data\pg_hba.conf" "host    all             all             127.0.0.1/32            trust"
@@ -12,6 +18,8 @@ services: postgresql
 build_script:
 - ps: >-
     psql -U postgres -c "CREATE ROLE appveyor LOGIN SUPERUSER CREATEDB CREATEROLE;"
+
+    psql -U postgres -c "SHOW TIME ZONE;"
 
     createdb hangfire_tests
 

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -190,6 +190,16 @@ namespace Hangfire.PostgreSql
       }
     }
 
+    /// <summary>
+    /// Timezone must be UTC for compatibility with Npgsql 6 and our usage of "timestamp without time zone" columns
+    /// See https://github.com/frankhommers/Hangfire.PostgreSql/issues/221
+    /// </summary>
+    /// <param name="connectionStringBuilder">The ConnectionStringBuilder to set the Timezone property for</param>
+    internal static void SetTimezoneToUtcForNpgsqlCompatibility(NpgsqlConnectionStringBuilder connectionStringBuilder)
+    {
+      connectionStringBuilder.Timezone = "UTC";
+    }
+
     internal NpgsqlConnection CreateAndOpenConnection()
     {
       NpgsqlConnection connection = _existingConnection;
@@ -200,6 +210,8 @@ namespace Hangfire.PostgreSql
         {
           connectionStringBuilder.Enlist = false;
         }
+
+        SetTimezoneToUtcForNpgsqlCompatibility(connectionStringBuilder);
 
         connection = new NpgsqlConnection(connectionStringBuilder.ToString());
         _connectionSetup?.Invoke(connection);

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
@@ -18,6 +18,16 @@ namespace Hangfire.PostgreSql.Tests
       _options = new PostgreSqlStorageOptions { PrepareSchemaIfNecessary = false, EnableTransactionScopeEnlistment = true };
     }
 
+    [Fact]
+    public void Connection_Timezone_Is_Set_To_UTC_For_Npgsql6_Compatibility()
+    {
+      PostgreSqlStorage storage = CreateStorage();
+
+      using (var connection = storage.CreateAndOpenConnection())
+      {
+        Assert.Equal("UTC", connection.Timezone);
+      }
+    }
 
     [Fact]
     public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()

--- a/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
@@ -46,6 +46,8 @@ namespace Hangfire.PostgreSql.Tests.Utils
     public static NpgsqlConnection CreateConnection()
     {
       NpgsqlConnectionStringBuilder csb = new(GetConnectionString());
+      PostgreSqlStorage.SetTimezoneToUtcForNpgsqlCompatibility(csb);
+
       NpgsqlConnection connection = new() {
         ConnectionString = csb.ToString(),
       };
@@ -57,6 +59,8 @@ namespace Hangfire.PostgreSql.Tests.Utils
     public static NpgsqlConnection CreateMasterConnection()
     {
       NpgsqlConnectionStringBuilder csb = new(GetMasterConnectionString());
+      PostgreSqlStorage.SetTimezoneToUtcForNpgsqlCompatibility(csb);
+
       NpgsqlConnection connection = new() {
         ConnectionString = csb.ToString(),
       };


### PR DESCRIPTION
## Overview
Ensure we always use UTC as the connection's timezone setting for Npgsql 6 compatibility when the default differs from UTC

Npgsql 6 introduced changes in to how DateTimes are handled with "timestamp without time zone" column, basically converting timestamps to the connection time zone as per https://www.npgsql.org/efcore/release-notes/6.0.html?tabs=annotations

This change ensures we restore previous behaviour by (re)setting the connection's session timezone to UTC, in case the default differs on the database server

## Notes
This PR builds upon #232 to demonstrate test success, see https://ci.appveyor.com/project/AndrewA/hangfire-postgresql/builds/42029218