### PR TITLE
Update Npgsql versions to 5.0.11 and 6.0.2

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -53,7 +53,7 @@
         <PackageId>Hangfire.PostgreSql.Npgsql5</PackageId>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Npgsql" Version="5.0.0" />
+        <PackageReference Include="Npgsql" Version="5.0.11" />
       </ItemGroup>
     </When>
     <Otherwise>
@@ -61,7 +61,7 @@
         <PackageId>Hangfire.PostgreSql</PackageId>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Npgsql" Version="6.0.0" />
+        <PackageReference Include="Npgsql" Version="6.0.2" />
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
This PR bumps the Npgsql versions to 5.0.11 and 6.0.2 which are the latest at https://www.nuget.org/packages/Npgsql/

This bumps the current use of 6.0.0 to 6.0.2, and 5.0.0 to 5.0.11

Note that the PR which restored Npgsql 5 behavior reverted the version from 5.0.7 to 5.0.0, so this bumps it back to the latest release of that major version.