### PR TITLE
Changed serialization failure when acquiring lock to debug log level

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
@@ -36,7 +36,7 @@ namespace Hangfire.PostgreSql
     private static void Log(string resource, string message, Exception ex)
     {
       bool isConcurrencyError = ex is PostgresException { SqlState: PostgresErrorCodes.SerializationFailure };
-      _logger.Log(isConcurrencyError ? LogLevel.Debug : LogLevel.Warn, () => $"{resource}: {message}", ex);
+      _logger.Log(isConcurrencyError ? LogLevel.Trace : LogLevel.Warn, () => $"{resource}: {message}", ex);
     }
 
     internal static void Acquire(IDbConnection connection, string resource, TimeSpan timeout, PostgreSqlStorageOptions options)

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLock.cs
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using System.Threading;
 using Dapper;
 using Hangfire.Logging;
+using Npgsql;
 
 namespace Hangfire.PostgreSql
 {
@@ -34,7 +35,8 @@ namespace Hangfire.PostgreSql
 
     private static void Log(string resource, string message, Exception ex)
     {
-      _logger.WarnException($"{resource}: {message}", ex);
+      bool isConcurrencyError = ex is PostgresException { SqlState: PostgresErrorCodes.SerializationFailure };
+      _logger.Log(isConcurrencyError ? LogLevel.Debug : LogLevel.Warn, () => $"{resource}: {message}", ex);
     }
 
     internal static void Acquire(IDbConnection connection, string resource, TimeSpan timeout, PostgreSqlStorageOptions options)


### PR DESCRIPTION
After implementing #188, people were scared that the library started having issues with acquiring locks. All of that was due to logging warnings, which was hidden completely before.

This PR changes the log level to Trace (which is very rarely used, mostly to investigate stuff) for serialization failures specifically (as that exception is handled properly). Any other exception will still be logged as warning.