### PR TITLE
Create index on the "set" table

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v17.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v17.sql
@@ -1,0 +1,14 @@
+﻿SET search_path = 'hangfire';
+
+DO
+$$
+    BEGIN
+        IF EXISTS(SELECT 1 FROM "schema" WHERE "version"::integer >= 17) THEN
+            RAISE EXCEPTION 'version-already-applied';
+        END IF;
+    END
+$$;
+
+CREATE INDEX IF NOT EXISTS ix_hangfire_set_key_score ON "set" (key, score);
+
+RESET search_path;

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
@@ -19,7 +19,7 @@ namespace Hangfire.PostgreSql.Tests
           PostgreSqlObjectsInstaller.Install(connection, schemaName);
 
           int lastVersion = connection.Query<int>($@"SELECT version FROM ""{schemaName}"".""schema""").Single();
-          Assert.Equal(16, lastVersion);
+          Assert.Equal(17, lastVersion);
 
           connection.Execute($@"DROP SCHEMA ""{schemaName}"" CASCADE;");
         });
@@ -38,7 +38,7 @@ namespace Hangfire.PostgreSql.Tests
           PostgreSqlObjectsInstaller.Install(connection, schemaName);
 
           int lastVersion = connection.Query<int>($@"SELECT version FROM ""{schemaName}"".""schema""").Single();
-          Assert.Equal(16, lastVersion);
+          Assert.Equal(17, lastVersion);
 
           connection.Execute($@"DROP SCHEMA ""{schemaName}"" CASCADE;");
         });


### PR DESCRIPTION
We noticed that the following query was between the top executed queries and also that the total time taken by this query was more than the total time taken by all the other queries for the hangfire db.

```
SELECT value 
FROM hangfire.set
WHERE key = ? AND score BETWEEN ? AND ? 
ORDER BY score 
LIMIT ?
```

We created the following index:

```
CREATE INDEX IF NOT EXISTS ix_hangfire_set_key_score ON hangfire."set" (key, score);
```

And that helped:

![image](https://user-images.githubusercontent.com/14803089/156161018-13b89ff0-17dd-4200-9984-2cbc4df241a6.png)

We thought it might make sense to add the creation of this index to the install scripts.
