### PR TITLE
Add connection factory for support dynamic create NpgsqlConnection in PostgreSqlStorage

### DIFF
--- a/src/Hangfire.PostgreSql/IConnectionFactory.cs
+++ b/src/Hangfire.PostgreSql/IConnectionFactory.cs
@@ -1,0 +1,35 @@
+﻿// This file is part of Hangfire.PostgreSql.
+// Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
+// 
+// Hangfire.PostgreSql is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire.PostgreSql  is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire.PostgreSql. If not, see <http://www.gnu.org/licenses/>.
+//
+// This work is based on the work of Sergey Odinokov, author of 
+// Hangfire. <http://hangfire.io/>
+//   
+//    Special thanks goes to him.
+
+using Npgsql;
+
+namespace Hangfire.PostgreSql;
+
+/// <summary>
+/// Connection factory for runtime create connection 
+/// </summary>
+public interface IConnectionFactory
+{
+  /// <summary>
+  /// Get or create NpgsqlConnection
+  /// </summary>
+  NpgsqlConnection GetOrCreateConnection();
+}

--- a/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
@@ -75,5 +75,39 @@ namespace Hangfire.PostgreSql
 
       return configuration.UseStorage(storage);
     }
+
+    /// <summary>
+    ///   Tells the bootstrapper to use PostgreSQL as a job storage
+    ///   with the given options, that can be accessed using the specified
+    ///   connection factory.
+    /// </summary>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="connectionFactory">Connection factory</param>
+    /// <param name="options">Advanced options</param>
+    public static IGlobalConfiguration<PostgreSqlStorage> UsePostgreSqlStorage(
+      this IGlobalConfiguration configuration,
+      IConnectionFactory connectionFactory,
+      PostgreSqlStorageOptions options)
+    {
+      PostgreSqlStorage storage = new(connectionFactory, options);
+
+      return configuration.UseStorage(storage);
+    }
+
+    /// <summary>
+    ///   Tells the bootstrapper to use PostgreSQL as a job storage
+    ///   with the given options, that can be accessed using the specified
+    ///   connection factory.
+    /// </summary>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="connectionFactory">Connection factory</param>
+    public static IGlobalConfiguration<PostgreSqlStorage> UsePostgreSqlStorage(
+      this IGlobalConfiguration configuration,
+      IConnectionFactory connectionFactory)
+    {
+      PostgreSqlStorage storage = new(connectionFactory, new PostgreSqlStorageOptions());
+
+      return configuration.UseStorage(storage);
+    }
   }
 }

--- a/tests/Hangfire.PostgreSql.Tests/Utils/DefaultConnectionFactory.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/DefaultConnectionFactory.cs
@@ -1,0 +1,14 @@
+﻿using Npgsql;
+
+namespace Hangfire.PostgreSql.Tests.Utils;
+
+public class DefaultConnectionFactory: IConnectionFactory
+{
+  /// <summary>
+  /// Get or create NpgsqlConnection
+  /// </summary>
+  public NpgsqlConnection GetOrCreateConnection()
+  {
+    return ConnectionUtils.CreateConnection();
+  }
+}


### PR DESCRIPTION
Hi. In the company where I work a lot of teams use your resources. Unfortunately `PostgreSqlStorage` only uses an existing connection or `connectionString f or the duration of the store.

In our postgres infrastructure databases can change their roles (for example, move from the **master** role to **read-only**) or addresses at any time the service is running.

In normal work we always create an `NpgsqlConnection` with the correct values ​​that we get through our own implementation of service discovery.

We really miss the support for dynamic connection creation in `PostgreSqlStorage`. I have implemented a simple support for such cases in the form of the `IConnectionFactory` interface which third-party developers can implement on their own side.

It would be great if such support was in your library directly.

I seen https://github.com/frankhommers/Hangfire.PostgreSql/issues/238. But in such cases it is limited because does not allow to work beautifully through the DI container. And the factory itself can be much more complicated than a delegate.

Using the factory you can create for example such extensions


```csharp
public static IServiceCollection AddHangfire(this IServiceCollection services)
{
    services.TryAddSingleton<IConnectionFactory, CustomConnectionFactory>();

    services.AddHangfire(
		(provider, configuration) =>
		{
			var connectionFactory = provider.GetRequiredService<IConnectionFactory>();
			configuration.UsePostgreSqlStorage(connectionFactory);
		});

    return services;
}
```
