### PR TITLE
Move connection string setup steps to constructor to Avoid "Collection was Modified" runtime error

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -61,7 +61,7 @@
         <PackageId>Hangfire.PostgreSql</PackageId>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Npgsql" Version="5.0.0" />
+        <PackageReference Include="Npgsql" Version="6.0.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -61,7 +61,7 @@
         <PackageId>Hangfire.PostgreSql</PackageId>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Npgsql" Version="6.0.0" />
+        <PackageReference Include="Npgsql" Version="5.0.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -222,11 +222,11 @@ namespace Hangfire.PostgreSql
 
       if (_connectionFactory is not null)
       {
-        connection = _connectionFactory.GetOrCreateConnection();
+        connection = new NpgsqlConnection(_connectionStringBuilder.ToString());
 
         if (!Options.EnableTransactionScopeEnlistment)
         {
-          if (connection.PostgresParameters.TryGetValue("Enlist", out string enlistValue) && enlistValue.ToLowerInvariant() == "true")
+          if (connection.ConnectionString.Contains("Enlist=True"))
           {
             throw new ArgumentException(
               $"TransactionScope enlistment must be enabled by setting {nameof(PostgreSqlStorageOptions)}.{nameof(Options.EnableTransactionScopeEnlistment)} to `true`.");

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -222,7 +222,7 @@ namespace Hangfire.PostgreSql
 
       if (_connectionFactory is not null)
       {
-        connection = new NpgsqlConnection(_connectionStringBuilder.ToString());
+        connection = _connectionFactory.GetOrCreateConnection();
 
         if (!Options.EnableTransactionScopeEnlistment)
         {

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -72,6 +72,10 @@ namespace Hangfire.PostgreSql
         throw new ArgumentException($"Connection string [{connectionString}] is not valid", nameof(connectionString));
       }
 
+      builder.Enlist = Options.EnableTransactionScopeEnlistment;
+
+      SetTimezoneToUtcForNpgsqlCompatibility(builder);
+
       _connectionStringBuilder = builder;
       _connectionSetup = connectionSetup;
 
@@ -203,12 +207,9 @@ namespace Hangfire.PostgreSql
     internal NpgsqlConnection CreateAndOpenConnection()
     {
       NpgsqlConnection connection = _existingConnection;
+
       if (connection == null)
       {
-        _connectionStringBuilder.Enlist = Options.EnableTransactionScopeEnlistment;
-
-        SetTimezoneToUtcForNpgsqlCompatibility(_connectionStringBuilder);
-
         connection = new NpgsqlConnection(_connectionStringBuilder.ToString());
         _connectionSetup?.Invoke(connection);
       }


### PR DESCRIPTION
Fix for issue: https://github.com/frankhommers/Hangfire.PostgreSql/issues/251

Also fixes the build issue master has when building for Npgsql 5 about the Settings property of the NpgsqlConnection Object:

https://ci.appveyor.com/project/vytautask/hangfire-postgresql-lel5h/branch/master/job/pw0va8ecg3c6vn6h

![image](https://user-images.githubusercontent.com/25250963/171058317-aac1407b-f897-4d4d-9856-e85aa6cc95c6.png)
