### PR TITLE
Fixed an issue #258 

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -279,7 +279,8 @@ namespace Hangfire.PostgreSql
       [InstantHandle] Func<DbConnection, IDbTransaction, T> func,
       IsolationLevel? isolationLevel = null)
     {
-      isolationLevel ??= IsolationLevel.ReadCommitted;
+      // Use isolation level of an already opened transaction in order to avoid isolation level conflict
+      isolationLevel ??= Transaction.Current?.IsolationLevel ?? IsolationLevel.ReadCommitted;
 
       if (!EnvironmentHelpers.IsMono())
       {

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Transactions;
 using Hangfire.PostgreSql.Tests.Utils;
 using Hangfire.Server;
 using Hangfire.Storage;
@@ -143,6 +144,20 @@ namespace Hangfire.PostgreSql.Tests
       };
       PostgreSqlStorage storage = new(new DefaultConnectionFactory(), option);
       Assert.Throws<ArgumentException>(() => storage.CreateAndOpenConnection());
+    }
+
+    [Fact]
+    public void CanUseTransaction_WithDifferentTransactionIsolationLevel()
+    {
+      using TransactionScope scope = new(TransactionScopeOption.Required,
+        new TransactionOptions() { IsolationLevel = IsolationLevel.Serializable });
+      
+      PostgreSqlStorage storage = new(new DefaultConnectionFactory(), _options);
+      NpgsqlConnection connection = storage.CreateAndOpenConnection();
+      
+      bool success = storage.UseTransaction(connection, (_, _) => true);
+      
+      Assert.True(success);
     }
 
     private PostgreSqlStorage CreateStorage()


### PR DESCRIPTION
Fixed https://github.com/frankhommers/Hangfire.PostgreSql/issues/258

Existing transaction taken into account for picking isolation level instead of always using ReadCommitted by default.