### PR TITLE
Implemented Counters Aggregator

### DIFF
--- a/src/Hangfire.PostgreSql/CountersAggregator.cs
+++ b/src/Hangfire.PostgreSql/CountersAggregator.cs
@@ -89,27 +89,27 @@ namespace Hangfire.PostgreSql
       // However extended support for SQL Server 2012 SP4 ends only on
       // July 12, 2022.
       return
-        $@"begin;
+        $@"BEGIN;
 
-insert into ""{_storage.Options.SchemaName}"".""aggregatedcounter"" (""key"", ""value"", ""expireat"")	
-      select
+INSERT INTO ""{_storage.Options.SchemaName}"".""aggregatedcounter"" (""key"", ""value"", ""expireat"")	
+      SELECT
       ""key"",
-      sum(""value""),
-      max(""expireat"")
-      from ""hangfire"".""counter""
-      group by
+      SUM(""value""),
+      MAX(""expireat"")
+      FROM ""{_storage.Options.SchemaName}"".""counter""
+      GROUP BY
       ""key""
-      on conflict(""key"") do
-        update
-          set
-      ""value"" = ""aggregatedcounter"".""value"" + excluded.""value"",
-      ""expireat"" = excluded.""expireat"";
+      ON CONFLICT(""key"") DO
+        UPDATE
+          SET
+      ""value"" = ""aggregatedcounter"".""value"" + EXCLUDED.""value"",
+      ""expireat"" = EXCLUDED.""expireat"";
 
-      delete from ""{_storage.Options.SchemaName}"".""counter""
-        where
-      ""key"" in (select ""key"" from ""{_storage.Options.SchemaName}"".""aggregatedcounter"" );
+      DELETE FROM ""{_storage.Options.SchemaName}"".""counter""
+        WHERE
+      ""key"" IN (SELECT ""key"" FROM ""{_storage.Options.SchemaName}"".""aggregatedcounter"" );
 
-      commit;
+      COMMIT;
       ";
     }
   }

--- a/src/Hangfire.PostgreSql/CountersAggregator.cs
+++ b/src/Hangfire.PostgreSql/CountersAggregator.cs
@@ -77,17 +77,8 @@ namespace Hangfire.PostgreSql
       cancellationToken.Wait(_interval);
     }
 
-    public override string ToString()
-    {
-      return GetType().ToString();
-    }
-
     private string GetAggregationQuery(PostgreSqlStorage storage)
     {
-      // Starting from SQL Server 2014 it's possible to get a query with
-      // much lower cost by adding a clustered index on [Key] column.
-      // However extended support for SQL Server 2012 SP4 ends only on
-      // July 12, 2022.
       return
         $@"BEGIN;
 

--- a/src/Hangfire.PostgreSql/CountersAggregator.cs
+++ b/src/Hangfire.PostgreSql/CountersAggregator.cs
@@ -1,0 +1,116 @@
+// This file is part of Hangfire.PostgreSql.
+// Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
+// 
+// Hangfire.PostgreSql is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire.PostgreSql  is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire.PostgreSql. If not, see <http://www.gnu.org/licenses/>.
+//
+// This work is based on the work of Sergey Odinokov, author of 
+// Hangfire. <http://hangfire.io/>
+//   
+//    Special thanks goes to him.
+
+using System;
+using System.Threading;
+using Dapper;
+using Hangfire.Common;
+using Hangfire.Logging;
+using Hangfire.Server;
+
+namespace Hangfire.PostgreSql
+{
+#pragma warning disable 618
+  internal class CountersAggregator : IServerComponent
+#pragma warning restore 618
+  {
+    // This number should be high enough to aggregate counters efficiently,
+    // but low enough to not to cause large amount of row locks to be taken.
+    // Lock escalation to page locks may pause the background processing.
+    private const int NumberOfRecordsInSinglePass = 1000;
+    private static readonly TimeSpan DelayBetweenPasses = TimeSpan.FromMilliseconds(500);
+
+    private readonly ILog _logger = LogProvider.For<CountersAggregator>();
+    private readonly TimeSpan _interval;
+    private readonly PostgreSqlStorage _storage;
+
+    public CountersAggregator(PostgreSqlStorage storage, TimeSpan interval)
+    {
+      if (storage == null) throw new ArgumentNullException(nameof(storage));
+
+      _storage = storage;
+      _interval = interval;
+    }
+
+    public void Execute(CancellationToken cancellationToken)
+    {
+      _logger.Debug("Aggregating records in 'Counter' table...");
+
+      int removedCount = 0;
+      
+      do
+      {
+        _storage.UseConnection(null, connection => {
+          removedCount = connection.Execute(GetAggregationQuery(_storage),
+            new { now = DateTime.UtcNow, count = NumberOfRecordsInSinglePass },
+            commandTimeout: 0);
+        });
+
+        if (removedCount >= NumberOfRecordsInSinglePass)
+        {
+          cancellationToken.Wait(DelayBetweenPasses);
+          cancellationToken.ThrowIfCancellationRequested();
+        }
+        // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
+      } while (removedCount >= NumberOfRecordsInSinglePass);
+
+      _logger.Trace("Records from the 'Counter' table aggregated.");
+
+      cancellationToken.Wait(_interval);
+    }
+
+    public override string ToString()
+    {
+      return GetType().ToString();
+    }
+
+    private string GetAggregationQuery(PostgreSqlStorage storage)
+    {
+      // Starting from SQL Server 2014 it's possible to get a query with
+      // much lower cost by adding a clustered index on [Key] column.
+      // However extended support for SQL Server 2012 SP4 ends only on
+      // July 12, 2022.
+      return
+        $@"begin;
+
+insert into ""{_storage.Options.SchemaName}"".""aggregatedcounter"" (""key"", ""value"", ""expireat"")	
+      select
+      ""key"",
+      sum(""value""),
+      max(""expireat"")
+      from ""hangfire"".""counter""
+      group by
+      ""key""
+      on conflict(""key"") do
+        update
+          set
+      ""value"" = ""aggregatedcounter"".""value"" + excluded.""value"",
+      ""expireat"" = excluded.""expireat"";
+
+      delete from ""{_storage.Options.SchemaName}"".""counter""
+        where
+      ""key"" in (select ""key"" from ""{_storage.Options.SchemaName}"".""aggregatedcounter"" );
+
+      commit;
+      ";
+    }
+  }
+}

--- a/src/Hangfire.PostgreSql/ExpirationManager.cs
+++ b/src/Hangfire.PostgreSql/ExpirationManager.cs
@@ -45,6 +45,7 @@ namespace Hangfire.PostgreSql
     };
 
     private static readonly string[] _processedTables = {
+      "aggregatedcounter",
       "counter",
       "job",
       "list",

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -527,10 +527,10 @@ namespace Hangfire.PostgreSql
         throw new ArgumentNullException(nameof(key));
       }
 
-      string query = $@"SELECT SUM(""VALUE"") FROM (
-            SELECT SUM(""value"") VALUE FROM ""{_options.SchemaName}"".""counter"" WHERE ""key"" = @Key
+      string query = $@"SELECT SUM(""value"") FROM (
+            SELECT SUM(""value"") ""value"" FROM ""{_options.SchemaName}"".""counter"" WHERE ""key"" = @Key
             UNION ALL
-            SELECT SUM(""value"") VALUE FROM ""{_options.SchemaName}"".""aggregatedcounter"" WHERE ""key"" = @Key) c";
+            SELECT SUM(""value"") ""value"" FROM ""{_options.SchemaName}"".""aggregatedcounter"" WHERE ""key"" = @Key) c";
 
       return _storage.UseConnection(_dedicatedConnection, connection => connection
           .QuerySingleOrDefault<long?>(query, new { Key = key }) ?? 0);

--- a/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlConnection.cs
@@ -527,7 +527,10 @@ namespace Hangfire.PostgreSql
         throw new ArgumentNullException(nameof(key));
       }
 
-      string query = $@"SELECT SUM(""value"") FROM ""{_options.SchemaName}"".""counter"" WHERE ""key"" = @Key";
+      string query = $@"SELECT SUM(""VALUE"") FROM (
+            SELECT SUM(""value"") VALUE FROM ""{_options.SchemaName}"".""counter"" WHERE ""key"" = @Key
+            UNION ALL
+            SELECT SUM(""value"") VALUE FROM ""{_options.SchemaName}"".""aggregatedcounter"" WHERE ""key"" = @Key) c";
 
       return _storage.UseConnection(_dedicatedConnection, connection => connection
           .QuerySingleOrDefault<long?>(query, new { Key = key }) ?? 0);

--- a/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlMonitoringApi.cs
@@ -291,13 +291,23 @@ namespace Hangfire.PostgreSql
           SELECT COUNT(*) 
           FROM ""{_storage.Options.SchemaName}"".""server"";
 
-          SELECT SUM(""value"") 
-          FROM ""{_storage.Options.SchemaName}"".""counter"" 
-          WHERE ""key"" = 'stats:succeeded';
+          SELECT SUM(""value"") FROM
+            (SELECT SUM(""value"") value
+            FROM ""{_storage.Options.SchemaName}"".""counter"" 
+            WHERE ""key"" = 'stats:succeeded'
+            UNION ALL
+            SELECT SUM(""value"") value
+            FROM ""{_storage.Options.SchemaName}"".""aggregatedcounter"" 
+            WHERE ""key"" = 'stats:succeeded') c;
 
-          SELECT SUM(""value"") 
-          FROM ""{_storage.Options.SchemaName}"".""counter"" 
-          WHERE ""key"" = 'stats:deleted';
+          SELECT SUM(""value"") FROM
+            (SELECT SUM(""value"") value
+            FROM ""{_storage.Options.SchemaName}"".""counter"" 
+            WHERE ""key"" = 'stats:deleted'
+            UNION ALL
+            SELECT SUM(""value"") value
+            FROM ""{_storage.Options.SchemaName}"".""aggregatedcounter"" 
+            WHERE ""key"" = 'stats:deleted') c;
 
           SELECT COUNT(*) 
           FROM ""{_storage.Options.SchemaName}"".""set"" 

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -171,8 +171,6 @@ namespace Hangfire.PostgreSql
     {
       yield return new ExpirationManager(this);
       yield return new CountersAggregator(this, Options.CountersAggregateInterval);
-
-      //TODO: add counters aggregator? (like https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.SqlServer/SqlServerStorage.cs#L154)
     }
 
     public override void WriteOptionsToLog(ILog logger)

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -170,6 +170,8 @@ namespace Hangfire.PostgreSql
     public override IEnumerable<IServerComponent> GetComponents()
     {
       yield return new ExpirationManager(this);
+      yield return new CountersAggregator(this, Options.CountersAggregateInterval);
+
       //TODO: add counters aggregator? (like https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.SqlServer/SqlServerStorage.cs#L154)
     }
 

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -33,6 +33,7 @@ namespace Hangfire.PostgreSql
     private TimeSpan _jobExpirationCheckInterval;
     private TimeSpan _queuePollInterval;
     private TimeSpan _transactionSerializationTimeout;
+    private TimeSpan _countersAggregateInterval;
 
     public PostgreSqlStorageOptions()
     {
@@ -41,6 +42,7 @@ namespace Hangfire.PostgreSql
       DistributedLockTimeout = TimeSpan.FromMinutes(10);
       TransactionSynchronisationTimeout = TimeSpan.FromMilliseconds(500);
       JobExpirationCheckInterval = TimeSpan.FromHours(1);
+      CountersAggregateInterval = TimeSpan.FromMinutes(5);
       SchemaName = "hangfire";
       AllowUnsafeValues = false;
       UseNativeDatabaseTransactions = true;
@@ -94,6 +96,15 @@ namespace Hangfire.PostgreSql
       }
     }
 
+    public TimeSpan CountersAggregateInterval
+    {
+      get => _countersAggregateInterval;
+      set {
+        ThrowIfValueIsNotPositive(value, nameof(CountersAggregateInterval));
+        _countersAggregateInterval = value;
+      }
+    }
+    
     /// <summary>
     ///   Gets or sets the number of records deleted in a single batch in expiration manager
     /// </summary>

--- a/src/Hangfire.PostgreSql/Scripts/Install.v18.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v18.sql
@@ -9,10 +9,10 @@ $$
     END
 $$;
 
-create table aggregatedcounter (
-    "id" bigserial primary key not null,
-    "key" text not null unique,
-    "value" int8 not null,
+CREATE TABLE aggregatedcounter (
+    "id" bigserial PRIMARY KEY NOT NULL,
+    "key" text NOT NULL UNIQUE,
+    "value" int8 NOT NULL,
     "expireat" timestamp
 );
 

--- a/src/Hangfire.PostgreSql/Scripts/Install.v18.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v18.sql
@@ -1,0 +1,19 @@
+﻿SET search_path = 'hangfire';
+
+DO
+$$
+    BEGIN
+        IF EXISTS(SELECT 1 FROM "schema" WHERE "version"::integer >= 18) THEN
+            RAISE EXCEPTION 'version-already-applied';
+        END IF;
+    END
+$$;
+
+create table aggregatedcounter (
+    "id" bigserial primary key not null,
+    "key" text not null unique,
+    "value" int8 not null,
+    "expireat" timestamp
+);
+
+RESET search_path;


### PR DESCRIPTION
Using Hangfire.SqlServer as a reference I implemented the counters aggregator functionality. The actual SQL implementation differs a bit (due to `MERGE` only being available in PostgreSQL 15) but I'm basically doing an upsert in the aggregate table, then deleting the records from the counters table, all within a transaction.

I also updated `PostgreSqlMonitoringApi.cs` to pull in the two values via a `UNION ALL` and sum them together, exactly as seen in the SQL Server implementation. Finally, I updated `ExpirationManager.cs` to expire old records in the new aggregate table. 

I'm unfamiliar with the schema management system here, so I just created a new v18 install script. If someone could test that functionality, that would be great. 