### PR TITLE
Fixed the transaction-related issues

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -30,11 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.8.1">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hangfire.Core" Version="1.7.27" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.28" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
@@ -1,4 +1,4 @@
-// This file is part of Hangfire.PostgreSql.
+﻿// This file is part of Hangfire.PostgreSql.
 // Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
 // 
 // Hangfire.PostgreSql is free software: you can redistribute it and/or modify
@@ -27,6 +27,10 @@ namespace Hangfire.PostgreSql
   public class PostgreSqlDistributedLockException : Exception
   {
     public PostgreSqlDistributedLockException(string message) : base(message)
+    {
+    }
+
+    public PostgreSqlDistributedLockException(string message, Exception innerException) : base(message, innerException)
     {
     }
   }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -47,6 +47,7 @@ namespace Hangfire.PostgreSql
       AllowUnsafeValues = false;
       UseNativeDatabaseTransactions = true;
       PrepareSchemaIfNecessary = true;
+      EnableTransactionScopeEnlistment = true;
       DeleteExpiredBatchSize = 1000;
     }
 

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -105,7 +105,7 @@ namespace Hangfire.PostgreSql
         _countersAggregateInterval = value;
       }
     }
-    
+
     /// <summary>
     ///   Gets or sets the number of records deleted in a single batch in expiration manager
     /// </summary>

--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -30,7 +30,6 @@ using Dapper;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage;
-using IsolationLevel = System.Transactions.IsolationLevel;
 
 namespace Hangfire.PostgreSql
 {
@@ -61,24 +60,7 @@ namespace Hangfire.PostgreSql
 
     private TransactionScope CreateTransactionScope()
     {
-      IsolationLevel isolationLevel = IsolationLevel.ReadCommitted;
-      TransactionScopeOption scopeOption = TransactionScopeOption.RequiresNew;
-      if (_storage.Options.EnableTransactionScopeEnlistment)
-      {
-        Transaction currentTransaction = Transaction.Current;
-        if (currentTransaction != null)
-        {
-          isolationLevel = currentTransaction.IsolationLevel;
-          scopeOption = TransactionScopeOption.Required;
-        }
-      }
-
-      TransactionOptions transactionOptions = new() {
-        IsolationLevel = isolationLevel,
-        Timeout = TransactionManager.MaximumTimeout,
-      };
-
-      return new TransactionScope(scopeOption, transactionOptions);
+      return _storage.CreateTransactionScope(null, TransactionManager.MaximumTimeout);
     }
 
     public override void ExpireJob(string jobId, TimeSpan expireIn)

--- a/src/Hangfire.PostgreSql/Utils/ConnectionStringBuilderExtensions.cs
+++ b/src/Hangfire.PostgreSql/Utils/ConnectionStringBuilderExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Npgsql;
+
+namespace Hangfire.PostgreSql.Utils
+{
+  internal static class ConnectionStringBuilderExtensions
+  {
+    /// <summary>
+    /// Timezone must be UTC for compatibility with Npgsql 6 and our usage of "timestamp without time zone" columns
+    /// See https://github.com/frankhommers/Hangfire.PostgreSql/issues/221
+    /// </summary>
+    /// <param name="connectionStringBuilder">The ConnectionStringBuilder to set the Timezone property for</param>
+    internal static void SetTimezoneToUtcForNpgsqlCompatibility(this NpgsqlConnectionStringBuilder connectionStringBuilder)
+    {
+      if (connectionStringBuilder == null)
+      {
+        return;
+      }
+
+      connectionStringBuilder.Timezone = "UTC";
+    }
+  }
+}

--- a/src/Hangfire.PostgreSql/Utils/TransactionHelpers.cs
+++ b/src/Hangfire.PostgreSql/Utils/TransactionHelpers.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Transactions;
+
+namespace Hangfire.PostgreSql.Utils
+{
+  public static class TransactionHelpers
+  {
+    internal static TransactionScope CreateTransactionScope(IsolationLevel? isolationLevel = IsolationLevel.ReadCommitted, bool enlist = true, TimeSpan? timeout = null)
+    {
+      TransactionScopeOption scopeOption = TransactionScopeOption.RequiresNew;
+      if (enlist)
+      {
+        Transaction currentTransaction = Transaction.Current;
+        if (currentTransaction != null)
+        {
+          isolationLevel = currentTransaction.IsolationLevel;
+          scopeOption = TransactionScopeOption.Required;
+        }
+      }
+
+      return new TransactionScope(
+        scopeOption,
+        new TransactionOptions {
+          IsolationLevel = isolationLevel.GetValueOrDefault(IsolationLevel.ReadCommitted),
+          Timeout = timeout.GetValueOrDefault(TransactionManager.DefaultTimeout),
+        });
+    }
+  }
+}

--- a/tests/Hangfire.PostgreSql.Tests/AssemblyAttributes.cs
+++ b/tests/Hangfire.PostgreSql.Tests/AssemblyAttributes.cs
@@ -1,0 +1,4 @@
+﻿using Xunit;
+
+// Running tests in parallel actually takes more time when we are cleaning the database for majority of tests. It's quicker to just let them run sequentially.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlDistributedLockFacts.cs
@@ -76,7 +76,7 @@ namespace Hangfire.PostgreSql.Tests
 
     [Fact]
     [CleanDatabase]
-    public void Acquire_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession_WhenDeadlockIsOccured()
+    public void Acquire_AcquiresExclusiveApplicationLock_WithUseNativeDatabaseTransactions_OnSession_WhenDeadlockOccurs()
     {
       PostgreSqlStorageOptions options = new() {
         SchemaName = GetSchemaName(),
@@ -177,7 +177,6 @@ namespace Hangfire.PostgreSql.Tests
       thread.Join();
     }
 
-
     [Fact]
     [CleanDatabase]
     public void Dispose_ReleasesExclusiveApplicationLock_WithUseNativeDatabaseTransactions()
@@ -220,7 +219,7 @@ namespace Hangfire.PostgreSql.Tests
 
     private void UseConnection(Action<NpgsqlConnection> action)
     {
-      _connection = _connection ?? ConnectionUtils.CreateConnection();
+      _connection ??= ConnectionUtils.CreateConnection();
       action(_connection);
     }
 

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlInstallerFacts.cs
@@ -46,8 +46,7 @@ namespace Hangfire.PostgreSql.Tests
 
       Assert.Null(ex);
     }
-    
-    
+
     private static void UseConnection(Action<NpgsqlConnection> action)
     {
       using (NpgsqlConnection connection = ConnectionUtils.CreateConnection())

--- a/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Hangfire.PostgreSql.Utils;
 using Npgsql;
 
 namespace Hangfire.PostgreSql.Tests.Utils
@@ -46,7 +47,7 @@ namespace Hangfire.PostgreSql.Tests.Utils
     public static NpgsqlConnection CreateConnection()
     {
       NpgsqlConnectionStringBuilder csb = new(GetConnectionString());
-      PostgreSqlStorage.SetTimezoneToUtcForNpgsqlCompatibility(csb);
+      csb.SetTimezoneToUtcForNpgsqlCompatibility();
 
       NpgsqlConnection connection = new() {
         ConnectionString = csb.ToString(),
@@ -59,7 +60,7 @@ namespace Hangfire.PostgreSql.Tests.Utils
     public static NpgsqlConnection CreateMasterConnection()
     {
       NpgsqlConnectionStringBuilder csb = new(GetMasterConnectionString());
-      PostgreSqlStorage.SetTimezoneToUtcForNpgsqlCompatibility(csb);
+      csb.SetTimezoneToUtcForNpgsqlCompatibility();
 
       NpgsqlConnection connection = new() {
         ConnectionString = csb.ToString(),


### PR DESCRIPTION
Potentially fixes #119.
Potentially fixes #237.
Fixes #271.
Fixes #274.

Changes how the transaction scope is opened - respects already-present ambient transaction.
Defaults `EnableTransactionScopeEnlistment` to `true` as that is the default behaviour in most of the ADO.NET providers anyway.