### PR TITLE
Codespaces/Long polling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:1": {}
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,9 @@
       ]
     }
   },
+  "containerEnv": {
+    "DOTNET_CLI_HOME": "/tmp/DOTNET_CLI_HOME"
+  },
   "postCreateCommand": "./.devcontainer/init.sh",
   "postStartCommand": "sudo service postgresql start"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,16 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2",
   "features": {
     "ghcr.io/devcontainers/features/dotnet:1": {}
+  },
+  "postCreateCommand": "./.devcontainer/init.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+		"ms-dotnettools.csharp",
+		"eamodio.gitlens",
+		"formulahendry.dotnet-test-explorer",
+		"mtxr.sqltools-driver-pg"
+	]
+    }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,15 +3,16 @@
   "features": {
     "ghcr.io/devcontainers/features/dotnet:1": {}
   },
-  "postCreateCommand": "./.devcontainer/init.sh",
   "customizations": {
     "vscode": {
       "extensions": [
-		"ms-dotnettools.csharp",
-		"eamodio.gitlens",
-		"formulahendry.dotnet-test-explorer",
-		"mtxr.sqltools-driver-pg"
-	]
+        "ms-dotnettools.csharp",
+        "eamodio.gitlens",
+        "formulahendry.dotnet-test-explorer",
+        "mtxr.sqltools-driver-pg"
+      ]
     }
-  }
+  },
+  "postCreateCommand": "./.devcontainer/init.sh",
+  "postStartCommand": "sudo service postgresql start"
 }

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,9 @@
+sudo apt update
+sudo apt install postgresql postgresql-contrib -y
+sudo cp ./.devcontainer/pg_hba.conf /etc/postgresql/12/main/pg_hba.conf
+sudo chown postgres:postgres /etc/postgresql/12/main/pg_hba.conf
+sudo service postgresql start
+
+sudo psql -U postgres -c "ALTER USER postgres PASSWORD 'password';"
+
+dotnet restore

--- a/.devcontainer/pg_hba.conf
+++ b/.devcontainer/pg_hba.conf
@@ -1,0 +1,104 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local         DATABASE  USER  METHOD  [OPTIONS]
+# host          DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl     DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostgssenc    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnogssenc  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# non-SSL TCP/IP socket.  Similarly, "hostgssenc" uses a
+# GSSAPI-encrypted TCP/IP socket, while "hostnogssenc" uses a
+# non-GSSAPI socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "scram-sha-256",
+# "gss", "sspi", "ident", "peer", "pam", "ldap", "radius" or "cert".
+# Note that "password" sends passwords in clear text; "md5" or
+# "scram-sha-256" are preferred since they send encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the server receives a
+# SIGHUP signal.  If you edit the file on a running system, you have to
+# SIGHUP the server for the changes to take effect, run "pg_ctl reload",
+# or execute "SELECT pg_reload_conf()".
+#
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                trust
+local   all             postgres                                md5
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections:
+host    all             all             ::1/128                 md5
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     peer
+host    replication     all             127.0.0.1/32            md5
+host    replication     all             ::1/128                 md5

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "sqltools.connections": [
+        {
+            "previewLimit": 50,
+            "server": "localhost",
+            "port": 5432,
+            "driver": "PostgreSQL",
+            "name": "localhost",
+            "database": "postgres",
+            "username": "postgres",
+            "password": "password"
+        }
+    ]
+}

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -71,7 +71,7 @@ namespace Hangfire.PostgreSql
         try
         {
           cancelListenSource?.Cancel();
-          listenTask.Wait();
+          listenTask?.Wait();
         }
         catch (AggregateException)
         {

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -224,7 +224,7 @@ namespace Hangfire.PostgreSql
 
         if(connection != null && requireNew)
         {
-          connection = connection.CloneWith(connection.Settings.ConnectionString);
+          connection = connection.CloneWith(connection.ConnectionString);
           _connectionSetup?.Invoke(connection);
         }
       }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -187,7 +187,7 @@ namespace Hangfire.PostgreSql
       }
     }
 
-    internal NpgsqlConnection CreateAndOpenConnection(bool requireNew = false)
+    internal NpgsqlConnection CreateAndOpenConnection()
     {
       NpgsqlConnection connection;
 
@@ -215,16 +215,9 @@ namespace Hangfire.PostgreSql
       else
       {
         connection = _existingConnection;
-
         if (connection == null)
         {
           connection = new NpgsqlConnection(_connectionStringBuilder.ToString());
-          _connectionSetup?.Invoke(connection);
-        }
-
-        if(connection != null && requireNew)
-        {
-          connection = connection.CloneWith(connection.ConnectionString);
           _connectionSetup?.Invoke(connection);
         }
       }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -187,7 +187,7 @@ namespace Hangfire.PostgreSql
       }
     }
 
-    internal NpgsqlConnection CreateAndOpenConnection()
+    internal NpgsqlConnection CreateAndOpenConnection(bool requireNew = false)
     {
       NpgsqlConnection connection;
 
@@ -215,9 +215,16 @@ namespace Hangfire.PostgreSql
       else
       {
         connection = _existingConnection;
+
         if (connection == null)
         {
           connection = new NpgsqlConnection(_connectionStringBuilder.ToString());
+          _connectionSetup?.Invoke(connection);
+        }
+
+        if(connection != null && requireNew)
+        {
+          connection = connection.CloneWith(connection.Settings.ConnectionString);
           _connectionSetup?.Invoke(connection);
         }
       }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -123,6 +123,7 @@ namespace Hangfire.PostgreSql
     public bool PrepareSchemaIfNecessary { get; set; }
     public string SchemaName { get; set; }
     public bool EnableTransactionScopeEnlistment { get; set; }
+    public bool EnableLongPolling { get; set; }
 
     private static void ThrowIfValueIsNotPositive(TimeSpan value, string fieldName)
     {


### PR DESCRIPTION
Support for Codespaces
- Added .devcontainer folder.
- Develop straight from Github by going to Code -> Codespaces.
- Containers include PostgreSQL 12 and VS Code extension to connect to database.
- Containers also include extension for tests allowing easy access to test cases.

Support for Long polling
- Added `EnableLongPolling` option which when enabled for PostgreSQL 11+ will use notifications to interrupt polling intervals.
- This allows for very long polling times (e.g. 10 minutes) that end immediately when jobs are queued.
- Because this feature uses Postgres notifications it should work across multiple processes across multiple machines as long as they share the same database.