### PR TITLE
Long polling test fix

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -95,7 +95,7 @@ namespace Hangfire.PostgreSql
       connection.Execute(enqueueJobSql,
         new { JobId = Convert.ToInt64(jobId, CultureInfo.InvariantCulture), Queue = queue });
 
-      if (_storage.Options.EnableLongPolling)
+      if (_storage.Options.EnableLongPolling && SupportsNotifications(connection))
       {
         connection.Execute($"NOTIFY {_jobNotificationChannel}");
       }

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -229,6 +229,11 @@ namespace Hangfire.PostgreSql
           connection.Open();
         }
 
+        if (Options.EnableLongPolling && !connection.SupportsNotifications())
+        {
+          throw new InvalidOperationException("Long polling is supported only with PostgreSQL version 11 or higher.");
+        }
+
         return connection;
       }
       catch
@@ -256,7 +261,7 @@ namespace Hangfire.PostgreSql
       isolationLevel ??= Transaction.Current?.IsolationLevel ?? IsolationLevel.ReadCommitted;
 
       if (!EnvironmentHelpers.IsMono())
-      {        
+      {
         T result = UseConnection(dedicatedConnection, connection => {
 
           using TransactionScope transaction = CreateTransactionScope(isolationLevel);
@@ -265,7 +270,7 @@ namespace Hangfire.PostgreSql
           transaction.Complete();
           return result;
 
-        });        
+        });
 
         return result;
       }

--- a/src/Hangfire.PostgreSql/Utils/DbConnectionExtensions.cs
+++ b/src/Hangfire.PostgreSql/Utils/DbConnectionExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Data;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Utils;
+
+internal static class DbConnectionExtensions
+{
+  private static bool? _supportsNotifications;
+
+  internal static bool SupportsNotifications(this IDbConnection connection)
+  {
+    if (_supportsNotifications.HasValue)
+    {
+      return _supportsNotifications.Value;
+    }
+
+    if (connection is not NpgsqlConnection npgsqlConnection)
+    {
+      _supportsNotifications = false;
+      return false;
+    }
+
+    if (npgsqlConnection.State != ConnectionState.Open)
+    {
+      npgsqlConnection.Open();
+    }
+
+    _supportsNotifications = npgsqlConnection.PostgreSqlVersion.Major >= 11;
+    return _supportsNotifications.Value;
+  }
+}


### PR DESCRIPTION
Test is failing for Postgres 9.6. This request includes the following:

- Long-polling (Notifications) test has been fixed to test scenarios where the database is lower than Postgres 11.
- Missing database version check was added job enqueue function.